### PR TITLE
chore: update runtime image to Debian 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir -p /app/data/oauth
 # ============================================================================
 # Runtime Stage: Minimal distroless image
 # ============================================================================
-FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+FROM gcr.io/distroless/cc-debian13:nonroot AS runtime
 
 # Copy the Python installation from builder
 COPY --from=builder --chown=nonroot:nonroot /python /python


### PR DESCRIPTION
This pull request updates the base image used in the runtime stage of the `Dockerfile` to a newer Debian version. This change ensures the application uses the latest security patches and system libraries.

* Docker base image update:
  * Changed the runtime stage base image from `gcr.io/distroless/cc-debian12:nonroot` to `gcr.io/distroless/cc-debian13:nonroot` in `Dockerfile`.