### PR TITLE
feat: category and tag support for transactions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ markers = [
   "budgets: budget-related tests",
   "insights: insight analysis tests",
   "rules: rule management tests",
+  "categories: category management tests",
+  "tags: tag management tests",
   "unit: marks tests as unit tests",
 ]
 

--- a/src/lampyrid/clients/firefly.py
+++ b/src/lampyrid/clients/firefly.py
@@ -20,12 +20,16 @@ from ..models.firefly_models import (
     BudgetLimitUpdate,
     BudgetSingle,
     BudgetStore,
+    CategoryArray,
+    CategorySingle,
     InsightGroup,
     InsightTotal,
     InsightTransfer,
     RuleArray,
     RuleSingle,
     RuleUpdate,
+    TagArray,
+    TagSingle,
     TransactionArray,
     TransactionSingle,
     TransactionStore,
@@ -345,6 +349,57 @@ class FireflyClient:
         self._handle_api_error(r)
         r.raise_for_status()
         return AvailableBudgetArray.model_validate(r.json())
+
+    # =========================================================================
+    # Category API Methods
+    # =========================================================================
+
+    async def get_categories(self, page: int = 1) -> CategoryArray:
+        """Get all categories."""
+        r = await self._client.get('/api/v1/categories', params={'page': page})
+        self._handle_api_error(r)
+        r.raise_for_status()
+        return CategoryArray.model_validate(r.json())
+
+    async def get_category(
+        self,
+        category_id: str,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+    ) -> CategorySingle:
+        """Get a single category by ID.
+
+        When start_date and end_date are provided, the response includes spending
+        and earning totals for that period.
+        """
+        params: Dict[str, Any] = {}
+        if start_date:
+            params['start'] = start_date.strftime('%Y-%m-%d')
+        if end_date:
+            params['end'] = end_date.strftime('%Y-%m-%d')
+
+        r = await self._client.get(f'/api/v1/categories/{category_id}', params=params)
+        self._handle_api_error(r)
+        r.raise_for_status()
+        return CategorySingle.model_validate(r.json())
+
+    # =========================================================================
+    # Tag API Methods
+    # =========================================================================
+
+    async def get_tags(self, page: int = 1) -> TagArray:
+        """Get all tags."""
+        r = await self._client.get('/api/v1/tags', params={'page': page})
+        self._handle_api_error(r)
+        r.raise_for_status()
+        return TagArray.model_validate(r.json())
+
+    async def get_tag(self, tag: str) -> TagSingle:
+        """Get a single tag by its name or numeric ID."""
+        r = await self._client.get(f'/api/v1/tags/{tag}')
+        self._handle_api_error(r)
+        r.raise_for_status()
+        return TagSingle.model_validate(r.json())
 
     # =========================================================================
     # Insight API Methods

--- a/src/lampyrid/clients/firefly.py
+++ b/src/lampyrid/clients/firefly.py
@@ -45,8 +45,11 @@ class FireflyClient:
     def __init__(self) -> None:
         """Initialize the Firefly III API client with authentication headers."""
         base = str(settings.firefly_base_url).rstrip('/')
+        # Append the API prefix here so individual methods use relative paths.
+        # Note: the trailing slash is required for httpx to join relative paths
+        # correctly (e.g. base '.../api/v1/' + 'accounts' -> '.../api/v1/accounts').
         self._client = httpx.AsyncClient(
-            base_url=base,
+            base_url=f'{base}/api/v1/',
             headers={
                 'Authorization': f'Bearer {settings.firefly_token}',
                 'Accept': 'application/json',
@@ -101,14 +104,14 @@ class FireflyClient:
         self, page: int = 1, type: AccountTypeFilter = AccountTypeFilter.all
     ) -> AccountArray:
         """List accounts with optional pagination and type filtering."""
-        r = await self._client.get('/api/v1/accounts', params={'page': page, 'type': type.value})
+        r = await self._client.get('accounts', params={'page': page, 'type': type.value})
         self._handle_api_error(r)
         r.raise_for_status()
         return AccountArray.model_validate(r.json())
 
     async def get_account(self, account_id: str) -> AccountSingle:
         """Get a single account by ID."""
-        r = await self._client.get(f'/api/v1/accounts/{account_id}')
+        r = await self._client.get(f'accounts/{account_id}')
         self._handle_api_error(r)
         r.raise_for_status()
         return AccountSingle.model_validate(r.json())
@@ -116,7 +119,7 @@ class FireflyClient:
     async def search_accounts(self, query: str, type: AccountTypeFilter) -> AccountArray:
         """Search accounts by name with optional type filtering."""
         r = await self._client.get(
-            '/api/v1/search/accounts',
+            'search/accounts',
             params={
                 'query': query,
                 'type': type.value,
@@ -131,7 +134,7 @@ class FireflyClient:
 
     async def create_account(self, account_store: AccountStore) -> AccountSingle:
         """Create a new account in Firefly III."""
-        r = await self._client.post('/api/v1/accounts', json=self._serialize_model(account_store))
+        r = await self._client.post('accounts', json=self._serialize_model(account_store))
         self._handle_api_error(r)
         r.raise_for_status()
         return AccountSingle.model_validate(r.json())
@@ -168,7 +171,7 @@ class FireflyClient:
             'limit': limit,
         }
 
-        r = await self._client.get('/api/v1/search/transactions', params=params)
+        r = await self._client.get('search/transactions', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return TransactionArray.model_validate(r.json())
@@ -176,7 +179,7 @@ class FireflyClient:
     async def create_transaction(self, transaction_store: TransactionStore) -> TransactionSingle:
         """Create a transaction with the given store data."""
         payload = self._serialize_model(transaction_store)
-        r = await self._client.post('/api/v1/transactions', json=payload)
+        r = await self._client.post('transactions', json=payload)
         self._handle_api_error(r, payload)
         r.raise_for_status()
         return TransactionSingle.model_validate(r.json())
@@ -186,7 +189,7 @@ class FireflyClient:
     ) -> TransactionSingle:
         """Update an existing transaction."""
         payload = self._serialize_model(transaction_update, exclude_unset=True)
-        r = await self._client.put(f'/api/v1/transactions/{transaction_id}', json=payload)
+        r = await self._client.put(f'transactions/{transaction_id}', json=payload)
         self._handle_api_error(r, payload)
         r.raise_for_status()
         return TransactionSingle.model_validate(r.json())
@@ -214,7 +217,7 @@ class FireflyClient:
         if transaction_type:
             params['type'] = transaction_type
 
-        r = await self._client.get('/api/v1/transactions', params=params)
+        r = await self._client.get('transactions', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return TransactionArray.model_validate(r.json())
@@ -243,35 +246,35 @@ class FireflyClient:
         if transaction_type:
             params['type'] = transaction_type
 
-        r = await self._client.get(f'/api/v1/accounts/{account_id}/transactions', params=params)
+        r = await self._client.get(f'accounts/{account_id}/transactions', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return TransactionArray.model_validate(r.json())
 
     async def get_transaction(self, transaction_id: str) -> TransactionSingle:
         """Get a single transaction by ID."""
-        r = await self._client.get(f'/api/v1/transactions/{transaction_id}')
+        r = await self._client.get(f'transactions/{transaction_id}')
         self._handle_api_error(r)
         r.raise_for_status()
         return TransactionSingle.model_validate(r.json())
 
     async def delete_transaction(self, transaction_id: str) -> bool:
         """Delete a transaction by ID."""
-        r = await self._client.delete(f'/api/v1/transactions/{transaction_id}')
+        r = await self._client.delete(f'transactions/{transaction_id}')
         self._handle_api_error(r)
         r.raise_for_status()
         return r.status_code == 204
 
     async def get_budgets(self) -> BudgetArray:
         """Get all budgets."""
-        r = await self._client.get('/api/v1/budgets')
+        r = await self._client.get('budgets')
         self._handle_api_error(r)
         r.raise_for_status()
         return BudgetArray.model_validate(r.json())
 
     async def get_budget(self, budget_id: str) -> BudgetSingle:
         """Get a single budget by ID."""
-        r = await self._client.get(f'/api/v1/budgets/{budget_id}')
+        r = await self._client.get(f'budgets/{budget_id}')
         self._handle_api_error(r)
         r.raise_for_status()
         return BudgetSingle.model_validate(r.json())
@@ -287,7 +290,7 @@ class FireflyClient:
         if end_date:
             params['end'] = end_date.strftime('%Y-%m-%d')
 
-        r = await self._client.get(f'/api/v1/budgets/{budget_id}/limits', params=params)
+        r = await self._client.get(f'budgets/{budget_id}/limits', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return BudgetLimitArray.model_validate(r.json())
@@ -297,7 +300,7 @@ class FireflyClient:
     ) -> BudgetLimitSingle:
         """Create a budget limit for a budget."""
         payload = self._serialize_model(budget_limit_store)
-        r = await self._client.post(f'/api/v1/budgets/{budget_id}/limits', json=payload)
+        r = await self._client.post(f'budgets/{budget_id}/limits', json=payload)
         self._handle_api_error(r, payload)
         r.raise_for_status()
         return BudgetLimitSingle.model_validate(r.json())
@@ -307,14 +310,14 @@ class FireflyClient:
     ) -> BudgetLimitSingle:
         """Update an existing budget limit."""
         payload = self._serialize_model(budget_limit_update, exclude_unset=True)
-        r = await self._client.put(f'/api/v1/budgets/{budget_id}/limits/{limit_id}', json=payload)
+        r = await self._client.put(f'budgets/{budget_id}/limits/{limit_id}', json=payload)
         self._handle_api_error(r, payload)
         r.raise_for_status()
         return BudgetLimitSingle.model_validate(r.json())
 
     async def delete_budget_limit(self, budget_id: str, limit_id: str) -> bool:
         """Delete a budget limit by ID."""
-        r = await self._client.delete(f'/api/v1/budgets/{budget_id}/limits/{limit_id}')
+        r = await self._client.delete(f'budgets/{budget_id}/limits/{limit_id}')
         self._handle_api_error(r)
         r.raise_for_status()
         return r.status_code == 204
@@ -322,14 +325,14 @@ class FireflyClient:
     async def create_budget(self, budget_store: BudgetStore) -> BudgetSingle:
         """Create a new budget."""
         payload = self._serialize_model(budget_store)
-        r = await self._client.post('/api/v1/budgets', json=payload)
+        r = await self._client.post('budgets', json=payload)
         self._handle_api_error(r, payload)
         r.raise_for_status()
         return BudgetSingle.model_validate(r.json())
 
     async def delete_budget(self, budget_id: str) -> bool:
         """Delete a budget by ID."""
-        r = await self._client.delete(f'/api/v1/budgets/{budget_id}')
+        r = await self._client.delete(f'budgets/{budget_id}')
         self._handle_api_error(r)
         r.raise_for_status()
         return r.status_code == 204
@@ -345,7 +348,7 @@ class FireflyClient:
         if end_date:
             params['end'] = end_date.strftime('%Y-%m-%d')
 
-        r = await self._client.get('/api/v1/available-budgets', params=params)
+        r = await self._client.get('available-budgets', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return AvailableBudgetArray.model_validate(r.json())
@@ -356,7 +359,7 @@ class FireflyClient:
 
     async def get_categories(self, page: int = 1) -> CategoryArray:
         """Get all categories."""
-        r = await self._client.get('/api/v1/categories', params={'page': page})
+        r = await self._client.get('categories', params={'page': page})
         self._handle_api_error(r)
         r.raise_for_status()
         return CategoryArray.model_validate(r.json())
@@ -378,7 +381,7 @@ class FireflyClient:
         if end_date:
             params['end'] = end_date.strftime('%Y-%m-%d')
 
-        r = await self._client.get(f'/api/v1/categories/{category_id}', params=params)
+        r = await self._client.get(f'categories/{category_id}', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return CategorySingle.model_validate(r.json())
@@ -389,14 +392,14 @@ class FireflyClient:
 
     async def get_tags(self, page: int = 1) -> TagArray:
         """Get all tags."""
-        r = await self._client.get('/api/v1/tags', params={'page': page})
+        r = await self._client.get('tags', params={'page': page})
         self._handle_api_error(r)
         r.raise_for_status()
         return TagArray.model_validate(r.json())
 
     async def get_tag(self, tag: str) -> TagSingle:
         """Get a single tag by its name or numeric ID."""
-        r = await self._client.get(f'/api/v1/tags/{tag}')
+        r = await self._client.get(f'tags/{tag}')
         self._handle_api_error(r)
         r.raise_for_status()
         return TagSingle.model_validate(r.json())
@@ -430,7 +433,7 @@ class FireflyClient:
     ) -> InsightTotal:
         """Get total expenses for a period."""
         params = self._build_insight_params(start_date, end_date, account_ids)
-        r = await self._client.get('/api/v1/insight/expense/total', params=params)
+        r = await self._client.get('insight/expense/total', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return InsightTotal.model_validate(r.json())
@@ -443,7 +446,7 @@ class FireflyClient:
     ) -> InsightGroup:
         """Get expenses grouped by expense account (vendor/payee)."""
         params = self._build_insight_params(start_date, end_date, account_ids)
-        r = await self._client.get('/api/v1/insight/expense/expense', params=params)
+        r = await self._client.get('insight/expense/expense', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return InsightGroup.model_validate(r.json())
@@ -456,7 +459,7 @@ class FireflyClient:
     ) -> InsightGroup:
         """Get expenses grouped by asset account (source)."""
         params = self._build_insight_params(start_date, end_date, account_ids)
-        r = await self._client.get('/api/v1/insight/expense/asset', params=params)
+        r = await self._client.get('insight/expense/asset', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return InsightGroup.model_validate(r.json())
@@ -472,7 +475,7 @@ class FireflyClient:
         params = self._build_insight_params(start_date, end_date, account_ids)
         if budget_ids:
             params['budgets[]'] = budget_ids
-        r = await self._client.get('/api/v1/insight/expense/budget', params=params)
+        r = await self._client.get('insight/expense/budget', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return InsightGroup.model_validate(r.json())
@@ -485,7 +488,7 @@ class FireflyClient:
     ) -> InsightTotal:
         """Get expenses without any budget assigned."""
         params = self._build_insight_params(start_date, end_date, account_ids)
-        r = await self._client.get('/api/v1/insight/expense/no-budget', params=params)
+        r = await self._client.get('insight/expense/no-budget', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return InsightTotal.model_validate(r.json())
@@ -500,7 +503,7 @@ class FireflyClient:
     ) -> InsightTotal:
         """Get total income for a period."""
         params = self._build_insight_params(start_date, end_date, account_ids)
-        r = await self._client.get('/api/v1/insight/income/total', params=params)
+        r = await self._client.get('insight/income/total', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return InsightTotal.model_validate(r.json())
@@ -513,7 +516,7 @@ class FireflyClient:
     ) -> InsightGroup:
         """Get income grouped by revenue account (income source)."""
         params = self._build_insight_params(start_date, end_date, account_ids)
-        r = await self._client.get('/api/v1/insight/income/revenue', params=params)
+        r = await self._client.get('insight/income/revenue', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return InsightGroup.model_validate(r.json())
@@ -526,7 +529,7 @@ class FireflyClient:
     ) -> InsightGroup:
         """Get income grouped by asset account (receiving account)."""
         params = self._build_insight_params(start_date, end_date, account_ids)
-        r = await self._client.get('/api/v1/insight/income/asset', params=params)
+        r = await self._client.get('insight/income/asset', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return InsightGroup.model_validate(r.json())
@@ -541,7 +544,7 @@ class FireflyClient:
     ) -> InsightTotal:
         """Get total transfers for a period."""
         params = self._build_insight_params(start_date, end_date, account_ids)
-        r = await self._client.get('/api/v1/insight/transfer/total', params=params)
+        r = await self._client.get('insight/transfer/total', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return InsightTotal.model_validate(r.json())
@@ -554,7 +557,7 @@ class FireflyClient:
     ) -> InsightTransfer:
         """Get transfers grouped by asset account with in/out breakdown."""
         params = self._build_insight_params(start_date, end_date, account_ids)
-        r = await self._client.get('/api/v1/insight/transfer/asset', params=params)
+        r = await self._client.get('insight/transfer/asset', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return InsightTransfer.model_validate(r.json())
@@ -565,14 +568,14 @@ class FireflyClient:
 
     async def get_rules(self, page: int = 1) -> RuleArray:
         """Get all rules with pagination."""
-        r = await self._client.get('/api/v1/rules', params={'page': page})
+        r = await self._client.get('rules', params={'page': page})
         self._handle_api_error(r)
         r.raise_for_status()
         return RuleArray.model_validate(r.json())
 
     async def get_rule(self, rule_id: str) -> RuleSingle:
         """Get a single rule by ID."""
-        r = await self._client.get(f'/api/v1/rules/{rule_id}')
+        r = await self._client.get(f'rules/{rule_id}')
         self._handle_api_error(r)
         r.raise_for_status()
         return RuleSingle.model_validate(r.json())
@@ -580,7 +583,7 @@ class FireflyClient:
     async def update_rule(self, rule_id: str, rule_update: RuleUpdate) -> RuleSingle:
         """Update an existing rule."""
         payload = self._serialize_model(rule_update, exclude_unset=True)
-        r = await self._client.put(f'/api/v1/rules/{rule_id}', json=payload)
+        r = await self._client.put(f'rules/{rule_id}', json=payload)
         self._handle_api_error(r, payload)
         r.raise_for_status()
         return RuleSingle.model_validate(r.json())
@@ -611,7 +614,7 @@ class FireflyClient:
         if account_ids:
             params['accounts[]'] = account_ids
 
-        r = await self._client.get(f'/api/v1/rules/{rule_id}/test', params=params)
+        r = await self._client.get(f'rules/{rule_id}/test', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return TransactionArray.model_validate(r.json())
@@ -642,7 +645,7 @@ class FireflyClient:
         if account_ids:
             params['accounts[]'] = account_ids
 
-        r = await self._client.post(f'/api/v1/rules/{rule_id}/trigger', params=params)
+        r = await self._client.post(f'rules/{rule_id}/trigger', params=params)
         self._handle_api_error(r)
         r.raise_for_status()
         return r.status_code == 204

--- a/src/lampyrid/clients/firefly.py
+++ b/src/lampyrid/clients/firefly.py
@@ -3,6 +3,7 @@
 import logging
 from datetime import date
 from typing import Any, Dict, Optional
+from urllib.parse import quote
 
 import httpx
 
@@ -399,7 +400,8 @@ class FireflyClient:
 
     async def get_tag(self, tag: str) -> TagSingle:
         """Get a single tag by its name or numeric ID."""
-        r = await self._client.get(f'tags/{tag}')
+        # Encode as a single path segment: tag names may contain '/', '?', '#', etc.
+        r = await self._client.get(f'tags/{quote(tag, safe="")}')
         self._handle_api_error(r)
         r.raise_for_status()
         return TagSingle.model_validate(r.json())

--- a/src/lampyrid/models/lampyrid_models.py
+++ b/src/lampyrid/models/lampyrid_models.py
@@ -10,10 +10,12 @@ from .firefly_models import (
     AccountTypeFilter,
     BudgetLimitRead,
     BudgetRead,
+    CategoryRead,
     RuleActionKeyword,
     RuleRead,
     RuleTriggerKeyword,
     ShortAccountTypeProperty,
+    TagRead,
     TransactionArray,
     TransactionRead,
     TransactionSingle,
@@ -21,6 +23,10 @@ from .firefly_models import (
     TransactionTypeFilter,
     TransactionTypeProperty,
 )
+
+# Alias so models can annotate a field literally named ``date`` without the
+# field name shadowing the ``date`` type within the class body.
+_DateType = date
 
 
 def utc_now():
@@ -117,6 +123,21 @@ class Transaction(BaseModel):
     currency_code: Optional[str] = Field(None, description='Currency code')
     budget_id: Optional[str] = Field(None, description='ID of the budget for this transaction')
     budget_name: Optional[str] = Field(None, description='Name of the budget for this transaction')
+    category_id: Optional[str] = Field(None, description='ID of the category for this transaction')
+    category_name: Optional[str] = Field(
+        None,
+        description=(
+            'Finer-grained classification of the transaction (e.g. "vegetables", '
+            '"personal hygiene"). One per transaction; complements the budget.'
+        ),
+    )
+    tags: Optional[List[str]] = Field(
+        None,
+        description=(
+            'Cross-cutting labels grouping transactions across budgets/categories/time '
+            '(e.g. a trip name, a project, a tax year). Multiple allowed.'
+        ),
+    )
 
     @classmethod
     def from_transaction_single(cls, trx: TransactionSingle) -> 'Transaction':
@@ -135,6 +156,9 @@ class Transaction(BaseModel):
             currency_code=inner_trx.currency_code,
             budget_id=inner_trx.budget_id,
             budget_name=inner_trx.budget_name,
+            category_id=inner_trx.category_id,
+            category_name=inner_trx.category_name,
+            tags=inner_trx.tags,
         )
 
     @classmethod
@@ -154,6 +178,9 @@ class Transaction(BaseModel):
             currency_code=first_trx.currency_code,
             budget_id=first_trx.budget_id,
             budget_name=first_trx.budget_name,
+            category_id=first_trx.category_id,
+            category_name=first_trx.category_name,
+            tags=first_trx.tags,
         )
 
     def to_transaction_split_store(self) -> TransactionSplitStore:
@@ -169,6 +196,9 @@ class Transaction(BaseModel):
             destination_name=self.destination_name,
             budget_id=self.budget_id,
             budget_name=self.budget_name,
+            category_id=self.category_id,
+            category_name=self.category_name,
+            tags=self.tags,
         )
 
 
@@ -259,6 +289,26 @@ class CreateWithdrawalRequest(BaseModel):
         None,
         description='Name of budget if ID is unknown. Will use ID if both provided.',
     )
+    category_id: Optional[str] = Field(
+        None,
+        description='ID of an existing category to classify this expense (from list_categories).',
+    )
+    category_name: Optional[str] = Field(
+        None,
+        description=(
+            'Finer-grained classification of the expense (e.g. "vegetables", '
+            '"personal hygiene"). Complements the budget. Unknown names are auto-created. '
+            'If both id and name are given, the id wins.'
+        ),
+    )
+    tags: Optional[List[str]] = Field(
+        None,
+        description=(
+            'Cross-cutting labels grouping transactions across budgets/categories/time '
+            '(e.g. a trip name, a project, a tax year). Multiple allowed; '
+            'unknown tags are auto-created.'
+        ),
+    )
 
     @model_validator(mode='after')
     def validate_destination_mutual_exclusivity(self):
@@ -308,6 +358,24 @@ class CreateDepositRequest(BaseModel):
             'Must be an asset account you own.'
         ),
     )
+    category_id: Optional[str] = Field(
+        None,
+        description='ID of an existing category to classify this income (from list_categories).',
+    )
+    category_name: Optional[str] = Field(
+        None,
+        description=(
+            'Finer-grained classification of the income (e.g. "salary", "refund"). '
+            'Unknown names are auto-created. If both id and name are given, the id wins.'
+        ),
+    )
+    tags: Optional[List[str]] = Field(
+        None,
+        description=(
+            'Cross-cutting labels grouping transactions across budgets/categories/time. '
+            'Multiple allowed; unknown tags are auto-created.'
+        ),
+    )
 
     @model_validator(mode='after')
     def validate_source_mutual_exclusivity(self):
@@ -340,6 +408,24 @@ class CreateTransferRequest(BaseModel):
     destination_id: str = Field(
         ...,
         description='ID of your account receiving the money. Must be an asset account you own.',
+    )
+    category_id: Optional[str] = Field(
+        None,
+        description='ID of an existing category to classify this transfer (from list_categories).',
+    )
+    category_name: Optional[str] = Field(
+        None,
+        description=(
+            'Finer-grained classification of the transfer. Unknown names are auto-created. '
+            'If both id and name are given, the id wins.'
+        ),
+    )
+    tags: Optional[List[str]] = Field(
+        None,
+        description=(
+            'Cross-cutting labels grouping transactions across budgets/categories/time. '
+            'Multiple allowed; unknown tags are auto-created.'
+        ),
     )
 
 
@@ -451,6 +537,14 @@ class SearchTransactionsRequest(BaseModel):
         description='Budget name to filter by (exact match)',
         examples=['Groceries', 'Dining Out'],
     )
+    tags: list[str] | None = Field(
+        None,
+        description=(
+            'Tag name(s) to filter by (exact match). When multiple are given, only '
+            'transactions carrying all of them are returned (AND logic).'
+        ),
+        examples=[['holiday-2024'], ['tax-deductible', 'business']],
+    )
 
     # Account filters
     account_contains: str | None = Field(
@@ -492,13 +586,16 @@ class SearchTransactionsRequest(BaseModel):
             self.account_contains,
             self.account_id,
         ]
-        # Consider a field provided if: (a) it's not None and not a string, or
+        # Consider a field provided if: (a) it's not None and not a string/list, or
         # (b) it's a string and not empty/whitespace-only
         has_criteria = any(
             (field is not None and not isinstance(field, str))
             or (isinstance(field, str) and field.strip() != '')
             for field in search_fields
         )
+        # Tags: provided only if the list is non-empty
+        if self.tags:
+            has_criteria = True
         if not has_criteria:
             raise ValueError('At least one search criterion must be provided')
         return self
@@ -933,8 +1030,23 @@ class UpdateTransactionRequest(BaseModel):
     budget_id: Optional[str] = Field(
         None, description='New budget ID to assign, or None to remove budget assignment'
     )
+    category_id: Optional[str] = Field(
+        None,
+        description='New category ID to assign (from list_categories). Overrules category_name.',
+    )
     category_name: Optional[str] = Field(
-        None, description='New category name for transaction classification'
+        None,
+        description=(
+            'New category name for transaction classification. Unknown names are auto-created.'
+        ),
+    )
+    tags: Optional[List[str]] = Field(
+        None,
+        description=(
+            'New set of tags for the transaction. REPLACES all existing tags on the '
+            'transaction; omit this field to leave existing tags unchanged. '
+            'Pass an empty list to clear all tags. Unknown tags are auto-created.'
+        ),
     )
 
 
@@ -1473,4 +1585,136 @@ class RuleExecuteResult(BaseModel):
             'The rule is queued but may still be processing. Check the rule '
             'later to confirm changes.'
         ),
+    )
+
+
+# =============================================================================
+# Category Models - Request and Response models for category management
+# =============================================================================
+
+
+def _sum_currency_entries(entries: Optional[List[Any]]) -> Optional[float]:
+    """Sum the absolute amounts of a Firefly currency/sum array (e.g. spent, earned).
+
+    Returns None when no entries are present (i.e. no date range was requested).
+    """
+    if not entries:
+        return None
+    total = 0.0
+    for entry in entries:
+        if entry.sum:
+            total += abs(float(entry.sum))
+    return total
+
+
+class Category(BaseModel):
+    """Simplified category model for MCP responses."""
+
+    id: str = Field(..., description='Unique identifier for the category', examples=['2'])
+    name: str = Field(..., description='Display name of the category', examples=['Groceries'])
+    notes: Optional[str] = Field(
+        None, description='Optional notes or description about this category'
+    )
+    spent: Optional[float] = Field(
+        None,
+        description=(
+            'Total spent in this category for the requested period (positive number). '
+            'Only present when a date range is requested.'
+        ),
+        examples=[120.0],
+    )
+    earned: Optional[float] = Field(
+        None,
+        description=(
+            'Total earned in this category for the requested period (positive number). '
+            'Only present when a date range is requested.'
+        ),
+        examples=[0.0],
+    )
+
+    @classmethod
+    def from_category_read(cls, category_read: 'CategoryRead') -> 'Category':
+        """Create a Category instance from a Firefly CategoryRead object."""
+        attrs = category_read.attributes
+        return cls(
+            id=category_read.id,
+            name=attrs.name,
+            notes=attrs.notes,
+            spent=_sum_currency_entries(attrs.spent),
+            earned=_sum_currency_entries(attrs.earned),
+        )
+
+
+class GetCategoryRequest(BaseModel):
+    """Request for getting a single category by ID, with optional spending period."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    id: str = Field(..., description='Unique identifier of the category to get details for')
+    start_date: Optional[date] = Field(
+        None,
+        description=(
+            'Start date (YYYY-MM-DD) for spending/earning totals, inclusive. '
+            'Must be provided together with end_date.'
+        ),
+    )
+    end_date: Optional[date] = Field(
+        None,
+        description=(
+            'End date (YYYY-MM-DD) for spending/earning totals, inclusive. '
+            'Must be provided together with start_date.'
+        ),
+    )
+
+    @model_validator(mode='after')
+    def _validate_period(self) -> 'GetCategoryRequest':
+        """Ensure start and end dates are provided together and ordered."""
+        if (self.start_date is None) != (self.end_date is None):
+            raise ValueError('Provide both start_date and end_date, or neither.')
+        if (
+            self.start_date is not None
+            and self.end_date is not None
+            and self.end_date < self.start_date
+        ):
+            raise ValueError('end_date must not be before start_date.')
+        return self
+
+
+# =============================================================================
+# Tag Models - Request and Response models for tag management
+# =============================================================================
+
+
+class Tag(BaseModel):
+    """Simplified tag model for MCP responses."""
+
+    id: str = Field(..., description='Unique identifier for the tag', examples=['2'])
+    tag: str = Field(..., description='The tag name', examples=['holiday-2024'])
+    description: Optional[str] = Field(None, description='Optional description of the tag')
+    # Annotate with _DateType to avoid the field name `date` shadowing the `date` type.
+    date: Optional[_DateType] = Field(
+        None, description='Optional date the tag is applicable to (YYYY-MM-DD)'
+    )
+
+    @classmethod
+    def from_tag_read(cls, tag_read: 'TagRead') -> 'Tag':
+        """Create a Tag instance from a Firefly TagRead object."""
+        attrs = tag_read.attributes
+        return cls(
+            id=tag_read.id,
+            tag=attrs.tag,
+            description=attrs.description,
+            date=attrs.date,
+        )
+
+
+class GetTagRequest(BaseModel):
+    """Request for getting a single tag by name or ID."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    tag: str = Field(
+        ...,
+        description='The tag name (e.g. "holiday-2024") or its numeric ID.',
+        min_length=1,
     )

--- a/src/lampyrid/services/__init__.py
+++ b/src/lampyrid/services/__init__.py
@@ -7,7 +7,16 @@ domain-specific business logic, aggregations, and multi-call operations.
 
 from .accounts import AccountService
 from .budgets import BudgetService
+from .categories import CategoryService
 from .insights import InsightService
+from .tags import TagService
 from .transactions import TransactionService
 
-__all__ = ['AccountService', 'BudgetService', 'InsightService', 'TransactionService']
+__all__ = [
+    'AccountService',
+    'BudgetService',
+    'CategoryService',
+    'InsightService',
+    'TagService',
+    'TransactionService',
+]

--- a/src/lampyrid/services/categories.py
+++ b/src/lampyrid/services/categories.py
@@ -22,14 +22,23 @@ class CategoryService:
         self._client = client
 
     async def list_categories(self) -> List[Category]:
-        """List all categories.
+        """List all categories, following pagination to return the full set.
 
         Returns:
                 List of categories (without spending totals).
 
         """
-        category_array = await self._client.get_categories()
-        return [Category.from_category_read(cat) for cat in category_array.data]
+        categories: List[Category] = []
+        page = 1
+        while True:
+            category_array = await self._client.get_categories(page=page)
+            categories.extend(Category.from_category_read(cat) for cat in category_array.data)
+            pagination = category_array.meta.pagination if category_array.meta else None
+            total_pages = pagination.total_pages if pagination else None
+            if not category_array.data or not total_pages or page >= total_pages:
+                break
+            page += 1
+        return categories
 
     async def get_category(self, req: GetCategoryRequest) -> Category:
         """Get a single category, optionally with spending/earning totals for a period.

--- a/src/lampyrid/services/categories.py
+++ b/src/lampyrid/services/categories.py
@@ -1,0 +1,47 @@
+"""Category Service for LamPyrid.
+
+This service handles category-related business logic and orchestrates
+operations between the MCP tools and the Firefly III client.
+"""
+
+from typing import List
+
+from ..clients.firefly import FireflyClient
+from ..models.lampyrid_models import Category, GetCategoryRequest
+
+
+class CategoryService:
+    """Service for reading Firefly III categories.
+
+    Categories are auto-created when an unknown category name is submitted on a
+    transaction, so this service exposes read operations only.
+    """
+
+    def __init__(self, client: FireflyClient) -> None:
+        """Initialize the category service with a FireflyClient instance."""
+        self._client = client
+
+    async def list_categories(self) -> List[Category]:
+        """List all categories.
+
+        Returns:
+                List of categories (without spending totals).
+
+        """
+        category_array = await self._client.get_categories()
+        return [Category.from_category_read(cat) for cat in category_array.data]
+
+    async def get_category(self, req: GetCategoryRequest) -> Category:
+        """Get a single category, optionally with spending/earning totals for a period.
+
+        Args:
+                req: Request containing the category ID and optional date range
+
+        Returns:
+                Category details, including spent/earned when a date range is provided.
+
+        """
+        category_single = await self._client.get_category(
+            req.id, start_date=req.start_date, end_date=req.end_date
+        )
+        return Category.from_category_read(category_single.data)

--- a/src/lampyrid/services/tags.py
+++ b/src/lampyrid/services/tags.py
@@ -1,0 +1,45 @@
+"""Tag Service for LamPyrid.
+
+This service handles tag-related business logic and orchestrates
+operations between the MCP tools and the Firefly III client.
+"""
+
+from typing import List
+
+from ..clients.firefly import FireflyClient
+from ..models.lampyrid_models import GetTagRequest, Tag
+
+
+class TagService:
+    """Service for reading Firefly III tags.
+
+    Tags are auto-created when an unknown tag is submitted on a transaction, so
+    this service exposes read operations only.
+    """
+
+    def __init__(self, client: FireflyClient) -> None:
+        """Initialize the tag service with a FireflyClient instance."""
+        self._client = client
+
+    async def list_tags(self) -> List[Tag]:
+        """List all tags.
+
+        Returns:
+                List of tags.
+
+        """
+        tag_array = await self._client.get_tags()
+        return [Tag.from_tag_read(tag) for tag in tag_array.data]
+
+    async def get_tag(self, req: GetTagRequest) -> Tag:
+        """Get a single tag by name or ID.
+
+        Args:
+                req: Request containing the tag name or numeric ID
+
+        Returns:
+                Tag details.
+
+        """
+        tag_single = await self._client.get_tag(req.tag)
+        return Tag.from_tag_read(tag_single.data)

--- a/src/lampyrid/services/tags.py
+++ b/src/lampyrid/services/tags.py
@@ -22,14 +22,23 @@ class TagService:
         self._client = client
 
     async def list_tags(self) -> List[Tag]:
-        """List all tags.
+        """List all tags, following pagination to return the full set.
 
         Returns:
                 List of tags.
 
         """
-        tag_array = await self._client.get_tags()
-        return [Tag.from_tag_read(tag) for tag in tag_array.data]
+        tags: List[Tag] = []
+        page = 1
+        while True:
+            tag_array = await self._client.get_tags(page=page)
+            tags.extend(Tag.from_tag_read(tag) for tag in tag_array.data)
+            pagination = tag_array.meta.pagination if tag_array.meta else None
+            total_pages = pagination.total_pages if pagination else None
+            if not tag_array.data or not total_pages or page >= total_pages:
+                break
+            page += 1
+        return tags
 
     async def get_tag(self, req: GetTagRequest) -> Tag:
         """Get a single tag by name or ID.

--- a/src/lampyrid/services/transactions.py
+++ b/src/lampyrid/services/transactions.py
@@ -65,6 +65,9 @@ class TransactionService:
             destination_name=req.destination_name,
             budget_id=req.budget_id,
             budget_name=req.budget_name,
+            category_id=req.category_id,
+            category_name=req.category_name,
+            tags=req.tags,
         )
         trx_store = TransactionStore(
             transactions=[trx],
@@ -94,6 +97,9 @@ class TransactionService:
             source_id=req.source_id,
             source_name=req.source_name,
             destination_id=req.destination_id,
+            category_id=req.category_id,
+            category_name=req.category_name,
+            tags=req.tags,
         )
         trx_store = TransactionStore(
             transactions=[trx],
@@ -122,6 +128,9 @@ class TransactionService:
             date=req.date,
             source_id=req.source_id,
             destination_id=req.destination_id,
+            category_id=req.category_id,
+            category_name=req.category_name,
+            tags=req.tags,
         )
         trx_store = TransactionStore(
             transactions=[trx],
@@ -326,6 +335,10 @@ class TransactionService:
         if req.budget:
             sanitized = FireflyClient._sanitize_value(req.budget)
             query_parts.append(f'budget_is:{sanitized}')
+        if req.tags:
+            for tag in req.tags:
+                sanitized = FireflyClient._sanitize_value(tag)
+                query_parts.append(f'tag_is:{sanitized}')
 
         # Account filters - sanitize user-provided values to escape special characters
         if req.account_contains:
@@ -370,8 +383,13 @@ class TransactionService:
             update_kwargs['destination_id'] = req.destination_id
         if req.budget_id is not None:
             update_kwargs['budget_id'] = req.budget_id
+        if req.category_id is not None:
+            update_kwargs['category_id'] = req.category_id
         if req.category_name is not None:
             update_kwargs['category_name'] = req.category_name
+        # tags uses replace semantics: an empty list clears all tags, None leaves unchanged
+        if req.tags is not None:
+            update_kwargs['tags'] = req.tags
 
         trx_split_update = TransactionSplitUpdate(**update_kwargs)
 

--- a/src/lampyrid/tools/__init__.py
+++ b/src/lampyrid/tools/__init__.py
@@ -9,8 +9,10 @@ from fastmcp import FastMCP
 from ..clients.firefly import FireflyClient
 from .accounts import create_accounts_server
 from .budgets import create_budgets_server
+from .categories import create_categories_server
 from .insights import create_insights_server
 from .rules import create_rules_server
+from .tags import create_tags_server
 from .transactions import create_transactions_server
 
 
@@ -26,6 +28,8 @@ def compose_all_servers(mcp: FastMCP, client: FireflyClient) -> None:
     accounts_server = create_accounts_server(client)
     transactions_server = create_transactions_server(client)
     budgets_server = create_budgets_server(client)
+    categories_server = create_categories_server(client)
+    tags_server = create_tags_server(client)
     insights_server = create_insights_server(client)
     rules_server = create_rules_server(client)
 
@@ -33,5 +37,7 @@ def compose_all_servers(mcp: FastMCP, client: FireflyClient) -> None:
     mcp.mount(accounts_server)
     mcp.mount(transactions_server)
     mcp.mount(budgets_server)
+    mcp.mount(categories_server)
+    mcp.mount(tags_server)
     mcp.mount(insights_server)
     mcp.mount(rules_server)

--- a/src/lampyrid/tools/categories.py
+++ b/src/lampyrid/tools/categories.py
@@ -1,0 +1,57 @@
+"""Category Management MCP Tools.
+
+This module provides MCP tools for reading Firefly III categories. Categories
+are auto-created when an unknown category name is submitted on a transaction,
+so only read operations are exposed here.
+"""
+
+from typing import List
+
+from fastmcp import FastMCP
+
+from ..clients.firefly import FireflyClient
+from ..models.lampyrid_models import Category, GetCategoryRequest
+from ..services.categories import CategoryService
+from ._annotations import readonly_annotations
+
+
+def create_categories_server(client: FireflyClient) -> FastMCP:
+    """Create a standalone FastMCP server for category management tools.
+
+    Args:
+        client: The FireflyClient instance for API interactions
+
+    Returns:
+        FastMCP server instance with category management tools registered
+
+    """
+    category_service = CategoryService(client)
+
+    categories_mcp = FastMCP('categories')
+
+    @categories_mcp.tool(
+        tags={'categories'},
+        annotations=readonly_annotations('List Categories'),
+    )
+    async def list_categories() -> List[Category]:
+        """List all categories.
+
+        Categories are a finer-grained classification of transactions (e.g.
+        "vegetables", "personal hygiene") that complement budgets. Use this to
+        find category IDs/names before assigning them to transactions.
+        """
+        return await category_service.list_categories()
+
+    @categories_mcp.tool(
+        tags={'categories'},
+        annotations=readonly_annotations('Get Category'),
+    )
+    async def get_category(req: GetCategoryRequest) -> Category:
+        """Retrieve a single category, optionally with spending for a period.
+
+        Provide start_date and end_date together to include the total spent and
+        earned in this category over that period.
+        """
+        return await category_service.get_category(req)
+
+    return categories_mcp

--- a/src/lampyrid/tools/tags.py
+++ b/src/lampyrid/tools/tags.py
@@ -1,0 +1,53 @@
+"""Tag Management MCP Tools.
+
+This module provides MCP tools for reading Firefly III tags. Tags are
+auto-created when an unknown tag is submitted on a transaction, so only read
+operations are exposed here.
+"""
+
+from typing import List
+
+from fastmcp import FastMCP
+
+from ..clients.firefly import FireflyClient
+from ..models.lampyrid_models import GetTagRequest, Tag
+from ..services.tags import TagService
+from ._annotations import readonly_annotations
+
+
+def create_tags_server(client: FireflyClient) -> FastMCP:
+    """Create a standalone FastMCP server for tag management tools.
+
+    Args:
+        client: The FireflyClient instance for API interactions
+
+    Returns:
+        FastMCP server instance with tag management tools registered
+
+    """
+    tag_service = TagService(client)
+
+    tags_mcp = FastMCP('tags')
+
+    @tags_mcp.tool(
+        tags={'tags'},
+        annotations=readonly_annotations('List Tags'),
+    )
+    async def list_tags() -> List[Tag]:
+        """List all tags.
+
+        Tags are cross-cutting labels that group transactions across budgets,
+        categories, and time (e.g. a trip, a project, a tax year). Use this to
+        discover existing tags before assigning or searching by them.
+        """
+        return await tag_service.list_tags()
+
+    @tags_mcp.tool(
+        tags={'tags'},
+        annotations=readonly_annotations('Get Tag'),
+    )
+    async def get_tag(req: GetTagRequest) -> Tag:
+        """Retrieve a single tag by its name or numeric ID."""
+        return await tag_service.get_tag(req)
+
+    return tags_mcp

--- a/tests/fixtures/transactions.py
+++ b/tests/fixtures/transactions.py
@@ -27,6 +27,9 @@ def make_create_withdrawal_request(
     destination_name: str | None = None,
     destination_id: str | None = None,
     budget_id: str | None = None,
+    category_name: str | None = None,
+    category_id: str | None = None,
+    tags: List[str] | None = None,
     date: datetime | None = None,
 ) -> CreateWithdrawalRequest:
     """Create a CreateWithdrawalRequest for testing.
@@ -38,6 +41,9 @@ def make_create_withdrawal_request(
         destination_name: Name of expense account (optional, exclusive with destination_id)
         destination_id: ID of expense account (optional, exclusive with destination_name)
         budget_id: Optional budget ID
+        category_name: Optional category name (auto-created if unknown)
+        category_id: Optional category ID
+        tags: Optional list of tags (auto-created if unknown)
         date: Transaction date (defaults to now)
 
     """
@@ -52,6 +58,9 @@ def make_create_withdrawal_request(
         destination_id=destination_id,
         destination_name=destination_name,
         budget_id=budget_id,
+        category_name=category_name,
+        category_id=category_id,
+        tags=tags,
     )
 
 
@@ -62,6 +71,8 @@ def make_create_deposit_request(
     *,
     source_name: str | None = None,
     source_id: str | None = None,
+    category_name: str | None = None,
+    tags: List[str] | None = None,
     date: datetime | None = None,
 ) -> CreateDepositRequest:
     """Create a CreateDepositRequest for testing.
@@ -72,6 +83,8 @@ def make_create_deposit_request(
         destination_id: ID of the destination asset account
         source_name: Name of the revenue account (optional, mutually exclusive with source_id)
         source_id: ID of the revenue account (optional, mutually exclusive with source_name)
+        category_name: Optional category name (auto-created if unknown)
+        tags: Optional list of tags (auto-created if unknown)
         date: Transaction date (defaults to now)
 
     """
@@ -85,6 +98,8 @@ def make_create_deposit_request(
         source_id=source_id,
         source_name=source_name,
         destination_id=destination_id,
+        category_name=category_name,
+        tags=tags,
     )
 
 
@@ -152,6 +167,7 @@ def make_search_transactions_request(
     transaction_type: str | None = None,
     category: str | None = None,
     budget: str | None = None,
+    tags: List[str] | None = None,
     account_contains: str | None = None,
     page: int = 1,
     limit: int = 50,
@@ -169,6 +185,7 @@ def make_search_transactions_request(
         type=transaction_type,  # ty:ignore[invalid-argument-type]
         category=category,
         budget=budget,
+        tags=tags,
         account_contains=account_contains,
         page=page,
         limit=limit,
@@ -184,6 +201,8 @@ def make_update_transaction_request(
     destination_id: str | None = None,
     budget_id: str | None = None,
     category_name: str | None = None,
+    category_id: str | None = None,
+    tags: List[str] | None = None,
 ) -> UpdateTransactionRequest:
     """Create an UpdateTransactionRequest for testing."""
     return UpdateTransactionRequest(
@@ -195,6 +214,8 @@ def make_update_transaction_request(
         destination_id=destination_id,
         budget_id=budget_id,
         category_name=category_name,
+        category_id=category_id,
+        tags=tags,
     )
 
 

--- a/tests/integration/test_categories.py
+++ b/tests/integration/test_categories.py
@@ -5,7 +5,7 @@ that categories submitted on transactions are auto-created and that spending
 totals are reported for a requested period.
 """
 
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from typing import List
 
 import pytest
@@ -16,8 +16,12 @@ from lampyrid.models.lampyrid_models import Account, Category, Transaction
 
 
 def _month_bounds() -> tuple[str, str]:
-    """Return (first-of-month, today) ISO date strings for the current month."""
-    today = date.today()
+    """Return (first-of-month, today) ISO date strings for the current UTC month.
+
+    Uses UTC to stay consistent with the UTC timestamps used when creating the
+    test transactions, avoiding month-boundary flakiness in non-UTC timezones.
+    """
+    today = datetime.now(timezone.utc).date()
     return today.replace(day=1).isoformat(), today.isoformat()
 
 
@@ -47,6 +51,7 @@ async def test_category_auto_created_and_listed(
         },
     )
     transaction = Transaction.model_validate(result.structured_content)
+    assert transaction.id is not None
     transaction_cleanup.append(transaction.id)
 
     # The transaction carries the category, with a freshly assigned id.
@@ -87,6 +92,7 @@ async def test_get_category_reports_period_spending(
         },
     )
     transaction = Transaction.model_validate(create.structured_content)
+    assert transaction.id is not None
     transaction_cleanup.append(transaction.id)
     category_id = transaction.category_id
     assert category_id is not None

--- a/tests/integration/test_categories.py
+++ b/tests/integration/test_categories.py
@@ -1,0 +1,118 @@
+"""Integration tests for category management tools.
+
+These exercise the category tools against a real Firefly III instance and verify
+that categories submitted on transactions are auto-created and that spending
+totals are reported for a requested period.
+"""
+
+from datetime import date, datetime, timezone
+from typing import List
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from lampyrid.models.lampyrid_models import Account, Category, Transaction
+
+
+def _month_bounds() -> tuple[str, str]:
+    """Return (first-of-month, today) ISO date strings for the current month."""
+    today = date.today()
+    return today.replace(day=1).isoformat(), today.isoformat()
+
+
+@pytest.mark.asyncio
+@pytest.mark.categories
+@pytest.mark.integration
+async def test_category_auto_created_and_listed(
+    mcp_client: Client,
+    test_asset_account: Account,
+    test_expense_account: str,
+    transaction_cleanup: List[str],
+):
+    """An unknown category submitted on a withdrawal is auto-created and listed."""
+    category_name = 'Integration Listed Category'
+
+    result = await mcp_client.call_tool(
+        'create_withdrawal',
+        {
+            'req': {
+                'amount': 12.0,
+                'description': 'Withdrawal with new category',
+                'source_id': test_asset_account.id,
+                'destination_name': test_expense_account,
+                'category_name': category_name,
+                'date': datetime.now(timezone.utc).isoformat(),
+            }
+        },
+    )
+    transaction = Transaction.model_validate(result.structured_content)
+    transaction_cleanup.append(transaction.id)
+
+    # The transaction carries the category, with a freshly assigned id.
+    assert transaction.category_name == category_name
+    assert transaction.category_id is not None
+
+    # list_categories returns it as a first-class object.
+    listed = await mcp_client.call_tool('list_categories', {})
+    categories = [Category.model_validate(c) for c in listed.structured_content['result']]
+    names = {c.name for c in categories}
+    assert category_name in names
+
+
+@pytest.mark.asyncio
+@pytest.mark.categories
+@pytest.mark.integration
+async def test_get_category_reports_period_spending(
+    mcp_client: Client,
+    test_asset_account: Account,
+    test_expense_account: str,
+    transaction_cleanup: List[str],
+):
+    """get_category returns spent for a period, and omits it when no range is given."""
+    category_name = 'Integration Spending Category'
+    amount = 37.5
+
+    create = await mcp_client.call_tool(
+        'create_withdrawal',
+        {
+            'req': {
+                'amount': amount,
+                'description': 'Withdrawal for spending category',
+                'source_id': test_asset_account.id,
+                'destination_name': test_expense_account,
+                'category_name': category_name,
+                'date': datetime.now(timezone.utc).isoformat(),
+            }
+        },
+    )
+    transaction = Transaction.model_validate(create.structured_content)
+    transaction_cleanup.append(transaction.id)
+    category_id = transaction.category_id
+    assert category_id is not None
+
+    # With a date range: spent reflects the withdrawal we just made.
+    start, end = _month_bounds()
+    with_period = await mcp_client.call_tool(
+        'get_category',
+        {'req': {'id': category_id, 'start_date': start, 'end_date': end}},
+    )
+    category = Category.model_validate(with_period.structured_content)
+    assert category.id == category_id
+    assert category.name == category_name
+    assert category.spent == amount
+
+    # Without a date range: no spending totals are populated.
+    without_period = await mcp_client.call_tool('get_category', {'req': {'id': category_id}})
+    bare = Category.model_validate(without_period.structured_content)
+    assert bare.spent is None
+    assert bare.earned is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.categories
+@pytest.mark.integration
+async def test_get_category_invalid_id_raises(mcp_client: Client):
+    """Requesting a non-existent category id raises an error."""
+    with pytest.raises(ToolError):
+        await mcp_client.call_tool('get_category', {'req': {'id': '99999999'}})

--- a/tests/integration/test_rules.py
+++ b/tests/integration/test_rules.py
@@ -22,7 +22,7 @@ async def _ensure_rule_group(firefly_client: FireflyClient) -> str:
         return _test_rule_group_id
 
     # Check for existing rule groups
-    r = await firefly_client._client.get('/api/v1/rule-groups')
+    r = await firefly_client._client.get('rule-groups')
     r.raise_for_status()
     groups = r.json().get('data', [])
     if groups:
@@ -31,7 +31,7 @@ async def _ensure_rule_group(firefly_client: FireflyClient) -> str:
 
     # Create one if none exist
     r = await firefly_client._client.post(
-        '/api/v1/rule-groups',
+        'rule-groups',
         json={'title': 'Test Rules', 'order': 1},
     )
     r.raise_for_status()
@@ -51,7 +51,7 @@ async def _create_rule_via_api(
     """Create a rule directly via Firefly III API and return its ID."""
     rule_group_id = await _ensure_rule_group(firefly_client)
     r = await firefly_client._client.post(
-        '/api/v1/rules',
+        'rules',
         json={
             'title': title,
             'rule_group_id': rule_group_id,
@@ -73,7 +73,7 @@ async def _create_rule_via_api(
 
 async def _delete_rule_via_api(firefly_client: FireflyClient, rule_id: str) -> None:
     """Delete a rule directly via Firefly III API."""
-    r = await firefly_client._client.delete(f'/api/v1/rules/{rule_id}')
+    r = await firefly_client._client.delete(f'rules/{rule_id}')
     r.raise_for_status()
 
 

--- a/tests/integration/test_tags.py
+++ b/tests/integration/test_tags.py
@@ -1,0 +1,92 @@
+"""Integration tests for tag management tools.
+
+These exercise the tag tools against a real Firefly III instance and verify that
+tags submitted on transactions are auto-created, listable, and retrievable by
+name.
+"""
+
+from datetime import datetime, timezone
+from typing import List
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from lampyrid.models.lampyrid_models import Account, Tag, Transaction
+
+
+@pytest.mark.asyncio
+@pytest.mark.tags
+@pytest.mark.integration
+async def test_tags_auto_created_and_listed(
+    mcp_client: Client,
+    test_asset_account: Account,
+    test_expense_account: str,
+    transaction_cleanup: List[str],
+):
+    """Unknown tags submitted on a withdrawal are auto-created and listed."""
+    tags = ['integration-tag-alpha', 'integration-tag-beta']
+
+    result = await mcp_client.call_tool(
+        'create_withdrawal',
+        {
+            'req': {
+                'amount': 8.25,
+                'description': 'Withdrawal with tags',
+                'source_id': test_asset_account.id,
+                'destination_name': test_expense_account,
+                'tags': tags,
+                'date': datetime.now(timezone.utc).isoformat(),
+            }
+        },
+    )
+    transaction = Transaction.model_validate(result.structured_content)
+    transaction_cleanup.append(transaction.id)
+    assert set(transaction.tags or []) == set(tags)
+
+    listed = await mcp_client.call_tool('list_tags', {})
+    tag_names = {Tag.model_validate(t).tag for t in listed.structured_content['result']}
+    assert set(tags).issubset(tag_names)
+
+
+@pytest.mark.asyncio
+@pytest.mark.tags
+@pytest.mark.integration
+async def test_get_tag_by_name(
+    mcp_client: Client,
+    test_asset_account: Account,
+    test_expense_account: str,
+    transaction_cleanup: List[str],
+):
+    """A tag can be retrieved by its name."""
+    tag_name = 'integration-tag-getbyname'
+
+    result = await mcp_client.call_tool(
+        'create_withdrawal',
+        {
+            'req': {
+                'amount': 5.0,
+                'description': 'Withdrawal for get_tag',
+                'source_id': test_asset_account.id,
+                'destination_name': test_expense_account,
+                'tags': [tag_name],
+                'date': datetime.now(timezone.utc).isoformat(),
+            }
+        },
+    )
+    transaction = Transaction.model_validate(result.structured_content)
+    transaction_cleanup.append(transaction.id)
+
+    fetched = await mcp_client.call_tool('get_tag', {'req': {'tag': tag_name}})
+    tag = Tag.model_validate(fetched.structured_content)
+    assert tag.tag == tag_name
+    assert tag.id is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.tags
+@pytest.mark.integration
+async def test_get_tag_unknown_raises(mcp_client: Client):
+    """Requesting a non-existent tag raises an error."""
+    with pytest.raises(ToolError):
+        await mcp_client.call_tool('get_tag', {'req': {'tag': 'definitely-not-a-real-tag-xyz-123'}})

--- a/tests/integration/test_tags.py
+++ b/tests/integration/test_tags.py
@@ -41,6 +41,7 @@ async def test_tags_auto_created_and_listed(
         },
     )
     transaction = Transaction.model_validate(result.structured_content)
+    assert transaction.id is not None
     transaction_cleanup.append(transaction.id)
     assert set(transaction.tags or []) == set(tags)
 
@@ -58,7 +59,7 @@ async def test_get_tag_by_name(
     test_expense_account: str,
     transaction_cleanup: List[str],
 ):
-    """A tag can be retrieved by its name."""
+    """A tag can be retrieved by its name and by its numeric ID."""
     tag_name = 'integration-tag-getbyname'
 
     result = await mcp_client.call_tool(
@@ -75,12 +76,20 @@ async def test_get_tag_by_name(
         },
     )
     transaction = Transaction.model_validate(result.structured_content)
+    assert transaction.id is not None
     transaction_cleanup.append(transaction.id)
 
-    fetched = await mcp_client.call_tool('get_tag', {'req': {'tag': tag_name}})
-    tag = Tag.model_validate(fetched.structured_content)
+    # Lookup by name.
+    by_name = await mcp_client.call_tool('get_tag', {'req': {'tag': tag_name}})
+    tag = Tag.model_validate(by_name.structured_content)
     assert tag.tag == tag_name
     assert tag.id is not None
+
+    # Lookup by the numeric ID returns the same tag.
+    by_id = await mcp_client.call_tool('get_tag', {'req': {'tag': tag.id}})
+    same_tag = Tag.model_validate(by_id.structured_content)
+    assert same_tag.id == tag.id
+    assert same_tag.tag == tag_name
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_transactions.py
+++ b/tests/integration/test_transactions.py
@@ -1642,6 +1642,7 @@ async def test_create_withdrawal_with_category_and_tags(
         },
     )
     transaction = Transaction.model_validate(result.structured_content)
+    assert transaction.id is not None
     transaction_cleanup.append(transaction.id)
 
     assert transaction.category_name == 'Txn Category'
@@ -1680,6 +1681,7 @@ async def test_create_deposit_with_category_and_tags(
         },
     )
     transaction = Transaction.model_validate(result.structured_content)
+    assert transaction.id is not None
     transaction_cleanup.append(transaction.id)
 
     assert transaction.category_name == 'Income Category'
@@ -1710,6 +1712,7 @@ async def test_update_transaction_replaces_and_clears_tags(
         },
     )
     transaction = Transaction.model_validate(create.structured_content)
+    assert transaction.id is not None
     transaction_cleanup.append(transaction.id)
     assert set(transaction.tags or []) == {'original-a', 'original-b'}
 
@@ -1755,9 +1758,53 @@ async def test_search_transactions_by_tag(
         },
     )
     transaction = Transaction.model_validate(create.structured_content)
+    assert transaction.id is not None
     transaction_cleanup.append(transaction.id)
 
     found = await mcp_client.call_tool('search_transactions', {'req': {'tags': [unique_tag]}})
     response = TransactionListResponse.model_validate(found.structured_content)
     ids = {t.id for t in response.transactions}
     assert transaction.id in ids
+
+
+@pytest.mark.asyncio
+@pytest.mark.transactions
+@pytest.mark.integration
+async def test_search_transactions_by_multiple_tags_uses_and(
+    mcp_client: Client,
+    test_asset_account: Account,
+    test_expense_account: str,
+    transaction_cleanup: List[str],
+):
+    """Searching by multiple tags returns only transactions carrying all of them."""
+    tag_a = 'multi-and-tag-a'
+    tag_b = 'multi-and-tag-b'
+
+    async def _make(description: str, tags: list[str]) -> str:
+        result = await mcp_client.call_tool(
+            'create_withdrawal',
+            {
+                'req': {
+                    'amount': 11.0,
+                    'description': description,
+                    'source_id': test_asset_account.id,
+                    'destination_name': test_expense_account,
+                    'tags': tags,
+                    'date': datetime.now(timezone.utc).isoformat(),
+                }
+            },
+        )
+        txn = Transaction.model_validate(result.structured_content)
+        assert txn.id is not None
+        transaction_cleanup.append(txn.id)
+        return txn.id
+
+    both_id = await _make('Has both tags', [tag_a, tag_b])
+    only_a_id = await _make('Has only tag a', [tag_a])
+
+    # Searching for both tags (AND) must return only the transaction carrying both.
+    found = await mcp_client.call_tool('search_transactions', {'req': {'tags': [tag_a, tag_b]}})
+    response = TransactionListResponse.model_validate(found.structured_content)
+    ids = {t.id for t in response.transactions}
+    assert both_id in ids
+    assert only_a_id not in ids

--- a/tests/integration/test_transactions.py
+++ b/tests/integration/test_transactions.py
@@ -64,6 +64,9 @@ async def test_create_withdrawal_basic(
             'currency_code': 'USD',
             'budget_id': None,
             'budget_name': None,
+            'category_id': None,
+            'category_name': None,
+            'tags': [],
         }
     )
 
@@ -112,6 +115,9 @@ async def test_create_withdrawal_with_budget(
             'currency_code': 'USD',
             'budget_id': '1',
             'budget_name': 'Test Budget',
+            'category_id': None,
+            'category_name': None,
+            'tags': [],
         }
     )
 
@@ -192,6 +198,9 @@ async def test_create_deposit_basic(
             'currency_code': 'USD',
             'budget_id': None,
             'budget_name': None,
+            'category_id': None,
+            'category_name': None,
+            'tags': [],
         }
     )
 
@@ -272,6 +281,9 @@ async def test_create_transfer_basic(
             'currency_code': 'USD',
             'budget_id': None,
             'budget_name': None,
+            'category_id': None,
+            'category_name': None,
+            'tags': [],
         }
     )
 
@@ -347,6 +359,9 @@ async def test_create_bulk_transactions(
             'currency_code': 'USD',
             'budget_id': None,
             'budget_name': None,
+            'category_id': None,
+            'category_name': None,
+            'tags': [],
         }
     )
     assert bulk_result.successful[1].model_dump() == snapshot(
@@ -363,6 +378,9 @@ async def test_create_bulk_transactions(
             'currency_code': 'USD',
             'budget_id': None,
             'budget_name': None,
+            'category_id': None,
+            'category_name': None,
+            'tags': [],
         }
     )
     assert bulk_result.successful[2].model_dump() == snapshot(
@@ -379,6 +397,9 @@ async def test_create_bulk_transactions(
             'currency_code': 'USD',
             'budget_id': None,
             'budget_name': None,
+            'category_id': None,
+            'category_name': None,
+            'tags': [],
         }
     )
 
@@ -438,6 +459,9 @@ async def test_get_transaction(
             'currency_code': 'USD',
             'budget_id': None,
             'budget_name': None,
+            'category_id': None,
+            'category_name': None,
+            'tags': [],
         }
     )
 
@@ -1197,6 +1221,9 @@ async def test_bulk_update_transactions_with_failure(
                     'currency_code': 'USD',
                     'budget_id': None,
                     'budget_name': None,
+                    'category_id': None,
+                    'category_name': None,
+                    'tags': [],
                 }
             ],
             'failed': [
@@ -1336,6 +1363,9 @@ async def test_create_bulk_transactions_non_atomic_partial_success(
                     'currency_code': 'USD',
                     'budget_id': None,
                     'budget_name': None,
+                    'category_id': None,
+                    'category_name': None,
+                    'tags': [],
                 },
                 {
                     'id': IsStr(min_length=1),
@@ -1350,6 +1380,9 @@ async def test_create_bulk_transactions_non_atomic_partial_success(
                     'currency_code': 'USD',
                     'budget_id': None,
                     'budget_name': None,
+                    'category_id': None,
+                    'category_name': None,
+                    'tags': [],
                 },
             ],
             'failed': [
@@ -1510,6 +1543,9 @@ async def test_bulk_update_transactions_partial_success(
                     'currency_code': 'USD',
                     'budget_id': None,
                     'budget_name': None,
+                    'category_id': None,
+                    'category_name': None,
+                    'tags': [],
                 },
                 {
                     'id': IsStr(min_length=1),
@@ -1524,6 +1560,9 @@ async def test_bulk_update_transactions_partial_success(
                     'currency_code': 'USD',
                     'budget_id': None,
                     'budget_name': None,
+                    'category_id': None,
+                    'category_name': None,
+                    'tags': [],
                 },
             ],
             'failed': [
@@ -1573,3 +1612,152 @@ async def test_bulk_update_transactions_all_fail(
     assert str(exc_info.value) == snapshot(
         "Error calling tool 'bulk_update_transactions': All 2 transaction updates failed"
     )
+
+
+# ==================== Category & Tag Operations ====================
+
+
+@pytest.mark.asyncio
+@pytest.mark.transactions
+@pytest.mark.integration
+async def test_create_withdrawal_with_category_and_tags(
+    mcp_client: Client,
+    test_asset_account: Account,
+    test_expense_account: str,
+    transaction_cleanup: List[str],
+):
+    """A withdrawal can be created with a category and tags, and they round-trip."""
+    result = await mcp_client.call_tool(
+        'create_withdrawal',
+        {
+            'req': {
+                'amount': 18.0,
+                'description': 'Withdrawal with category and tags',
+                'source_id': test_asset_account.id,
+                'destination_name': test_expense_account,
+                'category_name': 'Txn Category',
+                'tags': ['txn-tag-1', 'txn-tag-2'],
+                'date': datetime.now(timezone.utc).isoformat(),
+            }
+        },
+    )
+    transaction = Transaction.model_validate(result.structured_content)
+    transaction_cleanup.append(transaction.id)
+
+    assert transaction.category_name == 'Txn Category'
+    assert transaction.category_id is not None
+    assert set(transaction.tags or []) == {'txn-tag-1', 'txn-tag-2'}
+
+    # Round-trip: fetching the transaction returns the same metadata.
+    fetched = await mcp_client.call_tool('get_transaction', {'req': {'id': transaction.id}})
+    fetched_txn = Transaction.model_validate(fetched.structured_content)
+    assert fetched_txn.category_name == 'Txn Category'
+    assert set(fetched_txn.tags or []) == {'txn-tag-1', 'txn-tag-2'}
+
+
+@pytest.mark.asyncio
+@pytest.mark.transactions
+@pytest.mark.integration
+async def test_create_deposit_with_category_and_tags(
+    mcp_client: Client,
+    test_revenue_account: str,
+    test_asset_account: Account,
+    transaction_cleanup: List[str],
+):
+    """A deposit can be created with a category and tags."""
+    result = await mcp_client.call_tool(
+        'create_deposit',
+        {
+            'req': {
+                'amount': 220.0,
+                'description': 'Deposit with category and tags',
+                'source_name': test_revenue_account,
+                'destination_id': test_asset_account.id,
+                'category_name': 'Income Category',
+                'tags': ['income-tag'],
+                'date': datetime.now(timezone.utc).isoformat(),
+            }
+        },
+    )
+    transaction = Transaction.model_validate(result.structured_content)
+    transaction_cleanup.append(transaction.id)
+
+    assert transaction.category_name == 'Income Category'
+    assert transaction.tags == ['income-tag']
+
+
+@pytest.mark.asyncio
+@pytest.mark.transactions
+@pytest.mark.integration
+async def test_update_transaction_replaces_and_clears_tags(
+    mcp_client: Client,
+    test_asset_account: Account,
+    test_expense_account: str,
+    transaction_cleanup: List[str],
+):
+    """Updating tags replaces the full set; an empty list clears them."""
+    create = await mcp_client.call_tool(
+        'create_withdrawal',
+        {
+            'req': {
+                'amount': 9.0,
+                'description': 'Withdrawal for tag replacement',
+                'source_id': test_asset_account.id,
+                'destination_name': test_expense_account,
+                'tags': ['original-a', 'original-b'],
+                'date': datetime.now(timezone.utc).isoformat(),
+            }
+        },
+    )
+    transaction = Transaction.model_validate(create.structured_content)
+    transaction_cleanup.append(transaction.id)
+    assert set(transaction.tags or []) == {'original-a', 'original-b'}
+
+    # Replace: new tag set fully supersedes the old one.
+    replaced = await mcp_client.call_tool(
+        'update_transaction',
+        {'req': {'transaction_id': transaction.id, 'tags': ['replacement']}},
+    )
+    replaced_txn = Transaction.model_validate(replaced.structured_content)
+    assert replaced_txn.tags == ['replacement']
+
+    # Clear: an empty list removes all tags.
+    cleared = await mcp_client.call_tool(
+        'update_transaction',
+        {'req': {'transaction_id': transaction.id, 'tags': []}},
+    )
+    cleared_txn = Transaction.model_validate(cleared.structured_content)
+    assert (cleared_txn.tags or []) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.transactions
+@pytest.mark.integration
+async def test_search_transactions_by_tag(
+    mcp_client: Client,
+    test_asset_account: Account,
+    test_expense_account: str,
+    transaction_cleanup: List[str],
+):
+    """Transactions can be found by searching for one of their tags."""
+    unique_tag = 'search-by-tag-unique'
+    create = await mcp_client.call_tool(
+        'create_withdrawal',
+        {
+            'req': {
+                'amount': 14.0,
+                'description': 'Withdrawal findable by tag',
+                'source_id': test_asset_account.id,
+                'destination_name': test_expense_account,
+                'tags': [unique_tag],
+                'date': datetime.now(timezone.utc).isoformat(),
+            }
+        },
+    )
+    transaction = Transaction.model_validate(create.structured_content)
+    transaction_cleanup.append(transaction.id)
+
+    found = await mcp_client.call_tool('search_transactions', {'req': {'tags': [unique_tag]}})
+    response = TransactionListResponse.model_validate(found.structured_content)
+    ids = {t.id for t in response.transactions}
+    assert transaction.id in ids

--- a/tests/unit/test_firefly_client.py
+++ b/tests/unit/test_firefly_client.py
@@ -84,9 +84,9 @@ class TestFireflyClient:
         mock_http_client.post.assert_called_once()
         call_args = mock_http_client.post.call_args
 
-        # Check that it was called with correct relative URL
+        # Check that it was called with the exact relative URL
         # (the /api/v1/ prefix lives in the client's base_url)
-        assert 'accounts' in str(call_args[0])
+        assert call_args[0][0] == 'accounts'
         assert 'json' in call_args[1]
 
         # Verify result is validated
@@ -250,9 +250,9 @@ class TestFireflyClient:
         mock_http_client.post.assert_called_once()
         call_args = mock_http_client.post.call_args
 
-        # Check that it was called with correct relative URL
+        # Check that it was called with the exact relative URL
         # (the /api/v1/ prefix lives in the client's base_url)
-        assert 'budgets' in str(call_args[0])
+        assert call_args[0][0] == 'budgets'
         assert 'json' in call_args[1]
 
         # Verify result is validated

--- a/tests/unit/test_firefly_client.py
+++ b/tests/unit/test_firefly_client.py
@@ -45,8 +45,9 @@ class TestFireflyClient:
 
             client = FireflyClient()
 
-            # Verify the client was initialized with correct base URL
-            assert client._client.base_url == 'https://firefly.example.com'
+            # Verify the client was initialized with correct base URL.
+            # The /api/v1/ prefix is appended so methods can use relative paths.
+            assert client._client.base_url == 'https://firefly.example.com/api/v1/'
 
     def test_init_with_trailing_slash(self):
         """Test FireflyClient initialization with trailing slash."""
@@ -84,7 +85,8 @@ class TestFireflyClient:
         call_args = mock_http_client.post.call_args
 
         # Check that it was called with correct relative URL
-        assert '/api/v1/accounts' in str(call_args[0])
+        # (the /api/v1/ prefix lives in the client's base_url)
+        assert 'accounts' in str(call_args[0])
         assert 'json' in call_args[1]
 
         # Verify result is validated
@@ -249,7 +251,8 @@ class TestFireflyClient:
         call_args = mock_http_client.post.call_args
 
         # Check that it was called with correct relative URL
-        assert '/api/v1/budgets' in str(call_args[0])
+        # (the /api/v1/ prefix lives in the client's base_url)
+        assert 'budgets' in str(call_args[0])
         assert 'json' in call_args[1]
 
         # Verify result is validated

--- a/uv.lock
+++ b/uv.lock
@@ -25,14 +25,14 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.13.0"
+version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
 ]
 
 [[package]]
@@ -130,11 +130,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -172,14 +172,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -193,99 +193,96 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.14.1"
+version = "7.14.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/91/0a7c28934e50d8ac9a7b117712d176f2953c3170bccced5eaacfa3e96175/coverage-7.14.3.tar.gz", hash = "sha256:1a7563a443f3d53fdeb040ec8c9f7466aed7ca3dc5891aa09d3ca3625fa4387f", size = 924398, upload-time = "2026-06-22T23:10:25.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
-    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
-    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
-    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
-    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
-    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
-    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
-    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
-    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+    { url = "https://files.pythonhosted.org/packages/61/56/14e3b97facbfa1304dd19e676e26599ad359f04714bed32f7f1c5a88efdc/coverage-7.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:605ab2b566a22bd94834529d66d295c364aba84afd3e5498285c7a524017b1fc", size = 220741, upload-time = "2026-06-22T23:09:21.616Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1d/db378b5cca433b90b893f26dab728b280ddd89f272a1fdfed4aeaa05c686/coverage-7.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a3c2134809e80fac091bfed18a6991b5a5eb5df5ae32b17ac4f4f99864b73dd7", size = 221068, upload-time = "2026-06-22T23:09:23.452Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f0/3f8421b20d9c4fcd39be9a8ca3c3fda8bc204b44efbd09fede153afd3e2f/coverage-7.14.3-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c02efd507227bde9969cab0db8f48890eb3b5dcad6afac57a4792df4133543ce", size = 252117, upload-time = "2026-06-22T23:09:25.458Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ca/59ea35fb99743549ec8b37eff141ece4431fea590c89e536ed8032ef45cf/coverage-7.14.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1bb93c2aa61d2a5b38f1526546d95cf4132cb681e541a337bf8dfd092be816e5", size = 254622, upload-time = "2026-06-22T23:09:27.523Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/25/ec6de51ae7493b92a1cf74d1b763121c29636759167e2a593ba4db5881e4/coverage-7.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f502e948e03e866538048bba081c075caaa62e5bda6ea5b7432e45f587eb462a", size = 255968, upload-time = "2026-06-22T23:09:29.43Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/05/c8bfc77823f42b4664fb25842f13b567022f6f84a4c83c8ecbb16734b7cb/coverage-7.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9973ef2463f8e6cfb61a6324126bb3e17d67a85f22f58d856e583ea2e3ca6501", size = 258284, upload-time = "2026-06-22T23:09:31.397Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/15/1d1b242027124a32b26ef01f82018b8c4ef34ef174aa6aeba7b1eeef48e8/coverage-7.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9be4e7d4c5ca0427889f8f9d614bd630c2be741b1de7699bca3b2b6c0e41003e", size = 252143, upload-time = "2026-06-22T23:09:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b6/d2a9842fd2a5d7d27f1ac851c043a734a494ad75402c5331db3da79ed691/coverage-7.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a574912f3bde4b0619f6e97d01aa590b70998859244793769eb3a6df78ee56d3", size = 253976, upload-time = "2026-06-22T23:09:35.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/30/e1600ddf7e226db5558bb5323d2186fff00f505c4b764643ec89ce5d8175/coverage-7.14.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e343fb086c9cd780b38622fea7c369acd64c1a0724312149b5d769c387a2b1f5", size = 251942, upload-time = "2026-06-22T23:09:37.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/2c/9159de64f9dd648e324328d588a44cfab1e331eb5259ce1141afe2a92dfb/coverage-7.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:3c68df8e61f1e09633fefc7538297145623957a048534368c9d212782aa5e845", size = 256220, upload-time = "2026-06-22T23:09:39.165Z" },
+    { url = "https://files.pythonhosted.org/packages/91/67/b7f536cc2c124f48e91b22fbb741d2261f4e3d310faf6f76007f47566e5d/coverage-7.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3e5b550a128419373c2f6cec28a244207013ef15f5cbcff6a5ca09d1dfaaf027", size = 251756, upload-time = "2026-06-22T23:09:41.056Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ec/f3718038e2d4860c715a55428377ca7f6c75872caf98cabd982e1d76967d/coverage-7.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2bfc4dd0a912329eccc7484a7d0b2a38032b38c40663b1e1ac595f10c457954b", size = 253413, upload-time = "2026-06-22T23:09:43.306Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a5/91f11efeef89b3cc9b30461128db15b0511ef813ab889a7b7ab636b3a497/coverage-7.14.3-cp314-cp314-win32.whl", hash = "sha256:0423d64c013057a06e70f070f073cec4b0cbc7d2b27f3c7007292f2ff1d52965", size = 222946, upload-time = "2026-06-22T23:09:45.261Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fd/98ac9f524d9ec378de831c034dbdeb544ca7ef7d2d9c9996daf232a037fd/coverage-7.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:92c22e19ce64ca3f2ad751f16f14df1468b4c231bd6af97185063a9c292a0cb3", size = 223436, upload-time = "2026-06-22T23:09:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a0/7cd612d650a772a0ae80144443406bf61981c896c3d57c9e6e79fb2cdbd1/coverage-7.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:41de778bd41780586e2b04912079c73089ab5d839624e28db3bdb26de638da92", size = 222861, upload-time = "2026-06-22T23:09:49.384Z" },
+    { url = "https://files.pythonhosted.org/packages/55/57/017353fab573779c0d00448e47d102edd36c792f7b6f233a4d89a7a08384/coverage-7.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8427f370ca67db4c975d2a26acfc0e5783ca0b52444dbc50278ace0f35445949", size = 221474, upload-time = "2026-06-22T23:09:51.417Z" },
+    { url = "https://files.pythonhosted.org/packages/69/92/90cf1f1a5c468a9c1b7ba2716e0e205293ad9b02f5f573a6de4318b15ba1/coverage-7.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d8e88f335544a47e22ae2e45b344772925ec65166555c958720d5ed971880891", size = 221738, upload-time = "2026-06-22T23:09:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/c0/4df964fa539f8399fd7679c09c472d73744de334686fd3f01e3a2465ce4e/coverage-7.14.3-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:beaab199b9e5ceaf5a225e16a9d4df136f2a1eae0a5c20de1e277c8a5225f388", size = 263101, upload-time = "2026-06-22T23:09:55.895Z" },
+    { url = "https://files.pythonhosted.org/packages/06/76/e5d33b2576ae3bf2be2058cd1cae57774b61e400f2c3c58f3783dc2ffb4a/coverage-7.14.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3ff255799f5a1676c71c1c32ec01fd043aa09d57b3d95764b24992757184784", size = 265225, upload-time = "2026-06-22T23:09:57.904Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d2/e52419afe391a39ba27fdefaf0737d8e34bf03faef6ab3b3006545bbd0d0/coverage-7.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:878832eaac515b62decfa76965aed558775f86bf1fc8cca76993c0c84ae31aed", size = 267643, upload-time = "2026-06-22T23:09:59.938Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7a/f2625d8d5006b6b20fba5afaef00b24a763fe96476ea798a3076cbc1f84e/coverage-7.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:611e62cb9386096d81b63e0a05330750268617231e7bd598e1fe77482a2c58a5", size = 268762, upload-time = "2026-06-22T23:10:01.943Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bf/908024006bba57127354d74e938954b9c3cd765cc2e0412dc9c37b415cda/coverage-7.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:02c41de2a88011b893050fc9830267d927a50a215f7ad5ec17349db7090ccf26", size = 262208, upload-time = "2026-06-22T23:10:03.954Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a0/d4f9296441b909817442fdb26bd77a698f08272ec683a7394b00eb2e47a0/coverage-7.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:526ce9721116af23b1065089f0b75046fe521e7772ab94b641cd66b7a0421889", size = 265096, upload-time = "2026-06-22T23:10:05.936Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/da/4ae4f3f4e477b56a4ce1e5c48a35eff38a94b50130ce5bdc897024741cfc/coverage-7.14.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e4ed44705ca4bead6fc977a8b741f2145608289b33c8a9b42a95d0f15aedbf4d", size = 262699, upload-time = "2026-06-22T23:10:07.973Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/7a/6927148073ff32856d78baa77b4ddc07a9be7e90020f9db0661c4ca523a1/coverage-7.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2415902f385a23dcc4ccd26e0ba803249a169af6a930c003a4c715eeb9a5444e", size = 266433, upload-time = "2026-06-22T23:10:10.145Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a7/774f658dbe9c4c3f5daa86a87e0459ac3832e4e3cc67affe078547f727b9/coverage-7.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b75ee850fc2d7c831e883220c445b035f2224de2ba6103f1e56dbd237ab913f7", size = 261547, upload-time = "2026-06-22T23:10:12.191Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/14/a0c18c0376c43cbf973f43ef6ca20019c950597180e6396232f7b6a27102/coverage-7.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dc9b4e35e7c3920e925ba7f14886fd5fbe481232754624e832ddba66c7535635", size = 263859, upload-time = "2026-06-22T23:10:14.492Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ac/43a3d0f460af524b131a6191805bc5d18b806ab4e828fbf82e8c8c3af446/coverage-7.14.3-cp314-cp314t-win32.whl", hash = "sha256:7b27c822a8161afbe48e99f1adfb098d270ae7e0f7d7b0555ce110529bdb69cc", size = 223250, upload-time = "2026-06-22T23:10:16.758Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5f/d5e5c56b0712e96ce8f69fe7dbf229ff938b437bc50862743c8a0d2cea84/coverage-7.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:39e1dbbb6ff2c338e0196a482558a792a1de3aa64261196f5cdb3da016ad9cda", size = 224082, upload-time = "2026-06-22T23:10:19.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/35/947cbd5be1d3bcbbdc43d6791de8a56c6501903311d42915ae06a82815f0/coverage-7.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:68520c90babfa2d560eca6d497921ed3a4f469623bd709733124491b2aa8ef3f", size = 223400, upload-time = "2026-06-22T23:10:21.24Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e3/a0aa32bfa3a081951f60a23bc0e7b512891ef0eecda1153cf1d8ba36c6b1/coverage-7.14.3-py3-none-any.whl", hash = "sha256:fb7e18afb6e903c1a92401a2f0501ac277dca527bb9ca6fe1f691a8a0026a0e8", size = 212469, upload-time = "2026-06-22T23:10:23.405Z" },
 ]
 
 [[package]]
 name = "cryptography"
-version = "48.0.0"
+version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
-    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
-    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
-    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
-    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
-    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
-    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
-    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
-    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
-    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
-    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
-    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
-    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
-    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
-    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
-    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
 name = "cyclopts"
-version = "4.16.1"
+version = "4.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -293,28 +290,28 @@ dependencies = [
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/07/bf61d13de86d96a4c46aff00c9ca0eced44bcc8c3e16280605c1253e5720/cyclopts-4.16.1.tar.gz", hash = "sha256:8aa47bf92a5fb33abca5af05e576eecdb0d2f79893ad29238046df78370fc4a8", size = 181196, upload-time = "2026-05-25T15:29:08.518Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/89/f4c775c651d91f9cd8149f70baec94c902a34e5f17a7a67881881bcfb244/cyclopts-4.20.0.tar.gz", hash = "sha256:1d819de2b12dc6b1c9f17ce0f4937d82922c0b83ac846eb4b3289c9c9f321c9f", size = 190236, upload-time = "2026-06-29T15:04:42.253Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/8d/7f362c2fb8ef4decd2160bc24d4292c6ca658cc6d9a161b89ca5122bbdbf/cyclopts-4.16.1-py3-none-any.whl", hash = "sha256:617795392c4113a2c2cc7af716f20244900e87f23daa05442d1268d81472a592", size = 219020, upload-time = "2026-05-25T15:29:09.646Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d4/7243bc65d33c5ff5150569c42c8c1154aadae20b25638afe35f7f568489c/cyclopts-4.20.0-py3-none-any.whl", hash = "sha256:0b4337e9c11303d86b33d3f37c629dc01638f84591681e0e5611286bdd507646", size = 229383, upload-time = "2026-06-29T15:04:40.621Z" },
 ]
 
 [[package]]
 name = "datamodel-code-generator"
-version = "0.59.0"
+version = "0.66.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
-    { name = "black" },
+    { name = "black", marker = "sys_platform != 'emscripten'" },
     { name = "genson" },
     { name = "inflect" },
-    { name = "isort" },
+    { name = "isort", marker = "sys_platform != 'emscripten'" },
     { name = "jinja2" },
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/50/21488efdb515afc04039e19d876ee668d85a5c9590a3a4bb25b27f2b99c0/datamodel_code_generator-0.59.0.tar.gz", hash = "sha256:054e4d5568c27db5a993f6b3e1d34af53bd1f6d1b6c18b7166908b0f3dc04bd4", size = 1098070, upload-time = "2026-05-29T15:47:55.127Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/0c/3993ffaa7cd860a188ab9ad95a42786996c391f5d95b3d35fdd88bf70420/datamodel_code_generator-0.66.0.tar.gz", hash = "sha256:94d0cfcdb195df2ed30d54ec316529c11fb833df63813321ce5151662496756d", size = 1417080, upload-time = "2026-06-26T14:47:03.766Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/ef/8e2479e3ba432bb3333d0f01d6bdc520cc7f765ccbfac134b015d806bc2b/datamodel_code_generator-0.59.0-py3-none-any.whl", hash = "sha256:c8c119ab618d24a619d635fef7aa9c96b69e069a4d287c9adfc148ae28368a69", size = 316232, upload-time = "2026-05-29T15:47:53.228Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/34/ff212c3b295247a615f54beb37420618ddeb3fc08d71669ec73b2740cecd/datamodel_code_generator-0.66.0-py3-none-any.whl", hash = "sha256:cced93f8b9cfb9bbd4dce6fbb722b89aa37627a6af135300f45608e555b27f36", size = 407786, upload-time = "2026-06-26T14:47:01.864Z" },
 ]
 
 [package.optional-dependencies]
@@ -382,19 +379,19 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.3.1"
+version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/a9/5c5a01b6abd5346bf60b97cfd29e4a86661940c27dd562bfcda07fd03519/fastmcp-3.3.1.tar.gz", hash = "sha256:979362ea557de42a5f40342563c7e4b236bcc8e7cd192715f50030695d1a71cd", size = 28681699, upload-time = "2026-05-15T15:50:39.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/18/46beaec18c9f86a599ae3f9cdf6677dd6b50240cfd844d18233710b47f13/fastmcp-3.4.2.tar.gz", hash = "sha256:b468722946fc467c3796a6572f7a14d93d48c014cf8fea12910245220cbbe4e1", size = 28756849, upload-time = "2026-06-06T01:30:35.694Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/11/6b1bdada6ccfe647d615ae63f9106f8136aec17971e9361546af01c7d38e/fastmcp-3.3.1-py3-none-any.whl", hash = "sha256:862440c5c4d281363a5995eee59d77f0f7cac1f18869038729cecf03b02fc522", size = 7903, upload-time = "2026-05-15T15:50:36.424Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.3.1"
+version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -404,9 +401,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/a0/627103e517e1d0d6f1eec633d5662d13e776f01b45ad188e4f5f7478b438/fastmcp_slim-3.3.1.tar.gz", hash = "sha256:0957835fc59452e143ab2f4b7836d2d2df9b2d9958408edc79ba8b56232b2a88", size = 567007, upload-time = "2026-05-15T15:50:10.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/2e/d627b28b7403ecc526991ef732921b08bde010006e6148635f053fd29f4c/fastmcp_slim-3.4.2.tar.gz", hash = "sha256:290646e0955a516235a317151034559aa48336cb843d3f006131aedad8759bb4", size = 576291, upload-time = "2026-06-06T01:30:12.553Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/ee/97047f4cc2d7b1d46670d08d8ad01a96e7a748cc01c0b4b351ad8eddbc7a/fastmcp_slim-3.3.1-py3-none-any.whl", hash = "sha256:6cf1c2d77e3adb0d409d6825ed6b0b2a999062973e00b8eea03bd48bf9b4c043", size = 738644, upload-time = "2026-05-15T15:50:08.336Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/22afebf18df7260b09148199cbeb90cdcc4b3a4e1b5d7460e3591c3a7add/fastmcp_slim-3.4.2-py3-none-any.whl", hash = "sha256:bdc72492212681ca502755fa8acc0457f559295da1fc3dfc0599adc1c04b82f3", size = 749195, upload-time = "2026-06-06T01:30:11.22Z" },
 ]
 
 [package.optional-dependencies]
@@ -417,6 +414,7 @@ client = [
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
 ]
 server = [
     { name = "authlib" },
@@ -424,6 +422,7 @@ server = [
     { name = "exceptiongroup" },
     { name = "griffelib" },
     { name = "httpx" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
@@ -434,6 +433,7 @@ server = [
     { name = "pyperclip" },
     { name = "python-multipart" },
     { name = "pyyaml" },
+    { name = "starlette" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
@@ -451,11 +451,11 @@ wheels = [
 
 [[package]]
 name = "griffelib"
-version = "2.0.2"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
@@ -537,7 +537,7 @@ wheels = [
 
 [[package]]
 name = "inline-snapshot"
-version = "0.34.0"
+version = "0.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asttokens" },
@@ -546,9 +546,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/6b/70c657a50e61b51d6ac81611230edf50a30aca16b019c2a2fb77efee92a1/inline_snapshot-0.34.0.tar.gz", hash = "sha256:bb814ada843aba77356516dce5e07857bb76591c4258296a087a7cbe9e0d70f7", size = 2638680, upload-time = "2026-05-29T21:01:05.087Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/c3/b5c36ab59e355b8d7c59205b8903fa74458c6938c9691f7d7730404f94c9/inline_snapshot-0.34.2.tar.gz", hash = "sha256:d160cb6059e00916c2e846abc014ead6f01fb24479f13696fb8670d7a7937f67", size = 2641142, upload-time = "2026-06-19T21:17:27.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/cb/c279d8d0775ffabb8c10a7f9ff991cad155a9933cb931e98e81c1c2f9050/inline_snapshot-0.34.0-py3-none-any.whl", hash = "sha256:21a89c1ff18f1a20fa1a9b16567e8a29c01874458c3f2d80a0f97550f1809354", size = 90010, upload-time = "2026-05-29T21:01:03.621Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/2a/84fe7ef052ac666e95e7cabdf0905aa3f2c90b5a117419760b39b577602a/inline_snapshot-0.34.2-py3-none-any.whl", hash = "sha256:743a514a08ffd0d2d62878b0208d4def5041585affa7db6b89f0ca2e23552361", size = 90717, upload-time = "2026-06-19T21:17:25.629Z" },
 ]
 
 [[package]]
@@ -616,14 +616,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.7.0"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/c3/2f590052b55cbdd0ace470ee7ee1f685f6882051be93a9374891005623e2/joserfc-1.7.0.tar.gz", hash = "sha256:4aced6ab0c47846f0a531402aec2419a874b91e918df9c4c9da8a82fb559d6c4", size = 232967, upload-time = "2026-06-02T09:59:34.506Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/26/abe1ad855eb334b5ebc9c6495d4798e12bee70e5e8e815d54570710b8312/joserfc-1.7.2.tar.gz", hash = "sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947", size = 233183, upload-time = "2026-06-29T09:03:10.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/83/b6b62a66a06ce872d9429a5eb5ee20b2002fd9c331b953c94381c1f7c9f9/joserfc-1.7.0-py3-none-any.whl", hash = "sha256:17e5d7a5a35e65442b05efc435a3d5d46696ffa2c8a2ed0eea6f63fc268e3224", size = 70387, upload-time = "2026-06-02T09:59:33.264Z" },
+    { url = "https://files.pythonhosted.org/packages/13/80/d1b30336582cced4dce0dae776508a6011723e32f907bc7a702c0b25890a/joserfc-1.7.2-py3-none-any.whl", hash = "sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5", size = 70426, upload-time = "2026-06-29T09:03:09.393Z" },
 ]
 
 [[package]]
@@ -783,7 +783,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -801,9 +801,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -847,14 +847,14 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.42.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
 ]
 
 [[package]]
@@ -999,16 +999,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -1045,7 +1045,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1054,9 +1054,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1096,11 +1096,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.30"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4b/82/c8cd43a6e0719bf5a3b034f6726dd701f75829c08944c83d4b95d02ed0e8/python_multipart-0.0.30.tar.gz", hash = "sha256:0edfe0475c1f46ddd3ff7785a626f6118af32bdcf359bb21260367313bb32118", size = 46316, upload-time = "2026-05-31T19:24:55.198Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/fd/0318007beb234790993d3ec5afd051d1dbceb733e81e3afe2b981ece3f37/python_multipart-0.0.30-py3-none-any.whl", hash = "sha256:830964def8c90607ac5daa00514e3987815865713ade8d20febc9177ac0c3c5b", size = 29730, upload-time = "2026-05-31T19:24:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -1124,12 +1124,15 @@ wheels = [
 
 [[package]]
 name = "pywin32"
-version = "311"
+version = "312"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
-    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -1195,15 +1198,15 @@ wheels = [
 
 [[package]]
 name = "rich-rst"
-version = "2.0.1"
+version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pygments" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/56/3191bae66b08ccc637ea8120426068bcb361cc323c96404c310886937067/rich_rst-2.0.1.tar.gz", hash = "sha256:cbe236ed0901d1ec8427cc6a50bf0a34353ba28ad014dc24def68bfe7f3b9e68", size = 300570, upload-time = "2026-05-16T00:47:57.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/40/905f612e7bf105d7efefa923542e0c85b731cf29bcc1864331427dbc52b8/rich_rst-2.0.2.tar.gz", hash = "sha256:664a669801695c5a126151338f309ce3ea3e0ea081c89a4130b8a4f659911ed9", size = 300822, upload-time = "2026-06-25T17:24:14.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/3d/55c17d3ebdf3cd81356002afe5bef9bb8af631db2819785b6eac845b925b/rich_rst-2.0.1-py3-none-any.whl", hash = "sha256:7ee15f345ce25fa02b582c272a6cdbaf0c21243e38061cea273cff659bf3ef61", size = 272922, upload-time = "2026-05-16T00:47:55.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/5f/62fdf0f574ec75af7ada8ad27c1a67e3723d491143bc88d5371c25673949/rich_rst-2.0.2-py3-none-any.whl", hash = "sha256:7bc2923929c9bbc61aadfef2069b742446823b306af84cf9e0f56b965a3d3035", size = 273082, upload-time = "2026-06-25T17:24:09.557Z" },
 ]
 
 [[package]]
@@ -1274,27 +1277,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.15"
+version = "0.15.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
-    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
-    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
-    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
-    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]
@@ -1312,52 +1315,52 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.4.4"
+version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
 ]
 
 [[package]]
 name = "starlette"
-version = "1.2.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
 name = "ty"
-version = "0.0.42"
+version = "0.0.55"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/91/5b5ec4ed8721c18be8d9611778d7c07723cd755676f03b41bf0ea0caa5d3/ty-0.0.42.tar.gz", hash = "sha256:70f5553ac678fc63558d4d77b08a18a68a228f44be2a2fe1afc3f5988db662e7", size = 5769116, upload-time = "2026-06-01T19:40:32.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/48/f687c8d268e3581f2f104d1f2ac5944d5b5e841b3695c613b3f263e5bbf7/ty-0.0.55.tar.gz", hash = "sha256:88ca87073825a79a8327c550efcc86cec94344890244c5946f84c9e44a969f31", size = 6040230, upload-time = "2026-06-27T00:27:29.385Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/7c/2df5136ad7c0db69a3973b0b19da8f52bfacdc453c7dffc832d1bf7d23ff/ty-0.0.42-py3-none-linux_armv6l.whl", hash = "sha256:c08a0066610c13627b7d7ad758adb96ca99685791e641eb26837e20803851c53", size = 11544141, upload-time = "2026-06-01T19:40:41.065Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/82/96cf406d39d8976e825361a27e332224445812793060ac9506d8a5d32b39/ty-0.0.42-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3e944ee4e3d5cdaf70e4ea87f9dd474cc3db612837b50a3ce57afa8da400ecc2", size = 11283538, upload-time = "2026-06-01T19:40:26.758Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/fe/813b60b9332df835c16c05859ff5aac1896593d01b638ba0e461ede415ac/ty-0.0.42-py3-none-macosx_11_0_arm64.whl", hash = "sha256:603085306e4aac2ce592b39119a4b49ebf8b780cd394e2cfc7dbf3fd8228f954", size = 10711874, upload-time = "2026-06-01T19:40:28.77Z" },
-    { url = "https://files.pythonhosted.org/packages/07/64/1f609265be0302ce0f51aa03a27636d018947a76100ff1405258d8445e6c/ty-0.0.42-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a58f17834d7f078c49326a01111a5aac16c979a774b98cdfd8e2350068316676", size = 11213021, upload-time = "2026-06-01T19:40:45.01Z" },
-    { url = "https://files.pythonhosted.org/packages/88/c0/f147b2fde7cd01b5f77682937e85a5cdfe35f48b3f1d0f41021024cbd927/ty-0.0.42-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e6ed1027f313202c5c74e376007d1eb5d214494299beb0ea047078b8ad307d40", size = 11321604, upload-time = "2026-06-01T19:40:55.164Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/72/74a5e68a9bd194681f15c4aac7a0dfab378e76e7a107e8ecd93971a22377/ty-0.0.42-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:063838d2360c1d2c065b45ca76a56ecd6df07fff6570813e74183236559e16d9", size = 11802178, upload-time = "2026-06-01T19:40:19.558Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/9f/06a31dc9cc91faa2cb8a4bf2f0ba5f7a9a96a4828fb8434338682954ca86/ty-0.0.42-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3f9ed508dfae4cbc943d7766324dd9c57ac8302c8543505fc29cae8ed425fe9", size = 12358436, upload-time = "2026-06-01T19:40:48.968Z" },
-    { url = "https://files.pythonhosted.org/packages/06/33/a5bb1afcb671e0b9197f007264682b22f1063bf0e83c151eeaf9958f9047/ty-0.0.42-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fe1eb7d98472ac56ac19fec51c6ed8fe56d86ea0d232a11a127e8c62c882a66", size = 11997849, upload-time = "2026-06-01T19:40:42.951Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/8d/560e4ec4c2f69e68fa094bb93cd19b5eb92c9732d2e0f5e7cc3accde84c4/ty-0.0.42-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de75f9e78bfa81209f2f297528758977cfd4518ba35ef45a0acb516c892a27a5", size = 11869087, upload-time = "2026-06-01T19:40:24.38Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/dd/3794db15199c03eda60961690046a56c4fbf5d8ef073c82fe2402c851b8c/ty-0.0.42-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c63281f2f1d4df339117fcd4a6dfe17cb999f84eafe707b30e9ebbe26f0bb54a", size = 12059000, upload-time = "2026-06-01T19:40:34.982Z" },
-    { url = "https://files.pythonhosted.org/packages/98/9a/02b61cc65ecbd90f18bd02178845c5b756c78fb92643571e77df52c6eed8/ty-0.0.42-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:19e3856477f25255f772851fa7f16f5356c4e1927324d074d49c7bc9a9b211e1", size = 11195698, upload-time = "2026-06-01T19:40:37.109Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/d6/3927335c956b06a806269dcd2e5b46bc4284b0a95ecc6b0246094a1de28c/ty-0.0.42-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2f0f4acac9028264cee5ea0b88229df0b9b2586fc917dbadb6ee35a0e99e8b06", size = 11353487, upload-time = "2026-06-01T19:40:47.035Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/87/79e7ae4f5f9fb3bea5f3cfac2b4f8c60e905f13962e3c0d97f8b51a5bff6/ty-0.0.42-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ae244c84e30fdf2bb1a3cbf2b973da8aa535e57c701f12db44b2939604586c04", size = 11463474, upload-time = "2026-06-01T19:40:30.812Z" },
-    { url = "https://files.pythonhosted.org/packages/49/f9/73305ead1b3ccc3d79c04258877db2cd7908c6a6c2060d4e598deca384d2/ty-0.0.42-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2430434f4a52bec0da552ff6a061dcc1c5d11973259248679a1146d776c12f37", size = 11961710, upload-time = "2026-06-01T19:40:39.056Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/04/52b7325dad8d1a86653f90240208f3e3657bed5e3c8144eed367a0f736b0/ty-0.0.42-py3-none-win32.whl", hash = "sha256:984a55c2fe63b40dac03f5a144b99033c7ed720eb7611787e3f0bd49af8dcf12", size = 10783897, upload-time = "2026-06-01T19:40:22.189Z" },
-    { url = "https://files.pythonhosted.org/packages/94/d2/3d2d61255c76c0843766f00b39290115c23cc1cd4fcb0471d84a48f482f1/ty-0.0.42-py3-none-win_amd64.whl", hash = "sha256:f7afd81b10b377d9d4ce6aad355a4f47fd37d47f443118c01ca6e79d46fe6608", size = 11878640, upload-time = "2026-06-01T19:40:50.903Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/91/1eb0c1e3d558707ead7424f8bfd89b58f42e576714cbed7ad46dcceef34a/ty-0.0.42-py3-none-win_arm64.whl", hash = "sha256:4068c24b0b264fc9f1901e06b97988a041fcaa36c90f18d7747f05124701c7b3", size = 11202335, upload-time = "2026-06-01T19:40:53.155Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a3/1a90ba7e5a61c6d09adb92346ddba97668095fc257b577af433e5ac4f404/ty-0.0.55-py3-none-linux_armv6l.whl", hash = "sha256:31e83eef512d066542fe990fe1a3b814423abd1616376c54e48af7045b3e1749", size = 11677249, upload-time = "2026-06-27T00:26:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3a/669f9aa478c38243e213a2684db1502086026cfadc15bb1b29b7cbde030d/ty-0.0.55-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ab4bca857950608fea73e269e2da369d43e6467131de85160d68e2fa466fa248", size = 11444180, upload-time = "2026-06-27T00:26:54.576Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a4/6a4b2507a53ce6530c66c5b4fe0d58551eb1748ffa9e0696c32fdd55bbd4/ty-0.0.55-py3-none-macosx_11_0_arm64.whl", hash = "sha256:55032bfd31bf2c5355ee81bdc6407b144a1cc7ee41e5681dd1368e4cef2ba327", size = 10963134, upload-time = "2026-06-27T00:26:57.348Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ae/a3b1a0f1cc83b7d258662cb98aa80a720c2e671d0e8fa0d17a4d5d057a7a/ty-0.0.55-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1e049f69ce65b3c269af67624607f435e1c32319786c1e453ef9611502f295", size = 11493517, upload-time = "2026-06-27T00:26:59.26Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9f/311ce39065a979ef40a9b847f685c8e02464e53adf1671e081eea90640ca/ty-0.0.55-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:631409975c681d5a280fc5a99b7b32e9e801f33be7567c6b42ec331362f59d7d", size = 11460590, upload-time = "2026-06-27T00:27:01.425Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/3bf29aa77bd78aae48275153135a2052fa7d3ccdf1ecabeb99c8773abd66/ty-0.0.55-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e08cb0436e68b9351555ae8f2697138c9009b4d5b4ae4272232988b2a431a98f", size = 12098430, upload-time = "2026-06-27T00:27:03.596Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6e/e88411a88240b94640bba06fb6d0d92b247fbeef47ee2bc71f39e58c2558/ty-0.0.55-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16c215ad9f823829409b94ee188cfaa4563f6e1384f6ce3fecb1db75f6c7cf7c", size = 12673086, upload-time = "2026-06-27T00:27:05.589Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/7e/8f1762fb7f9245a68ba5ae338d73c59403ce57554e5d311b8bb55027b0ec/ty-0.0.55-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b510eb8f4032baf11b7aee2f1d53babc3b4ca03939b9cdcf6a9d15761d575188", size = 12242559, upload-time = "2026-06-27T00:27:07.714Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1f/143657daf2670d977dac83435f1fe03d4843efb798d8e1e75950e541aadd/ty-0.0.55-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ddc05e7959709c3b9b83aa627128a80446865e3c1a4882638dcff6d776dc34a", size = 12021409, upload-time = "2026-06-27T00:27:09.881Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/30/69487c439dd1fad3a4a3d96f0a472193de297eaba6fc4b8ea687ce434ac2/ty-0.0.55-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:636e8e5078787b8c6916c94e1406719f10189a4ca6b37b813a5922ce5857a8c7", size = 12303807, upload-time = "2026-06-27T00:27:11.986Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ca/cd88b6493dafc7db077f5e17c0438eb3af6e2d6d08f616dbb52a8ddfd567/ty-0.0.55-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ef7d6deaacb73fec603666b5471f1dc5a5699aa84e11a6d4d644dd07ca72121e", size = 11441263, upload-time = "2026-06-27T00:27:14.087Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/fe/66b6915671653ab739f71e4f1b0528e69da64429b7ebf3840c625b6e43f2/ty-0.0.55-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:9aeea0fe5875d3cf37faf0e44d0fdf9669335467749741b8fc0103916fb5cd32", size = 11484584, upload-time = "2026-06-27T00:27:16.311Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4f/7a9c0bbac8b899e9f6c0ec110c6612f52e4db35f6bb17ddc0ef60384fa3e/ty-0.0.55-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0b699c01310dbd2705a07c97c5f4aaeedef61bd9adeea2e7c46aed32401d3576", size = 11759309, upload-time = "2026-06-27T00:27:18.471Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/de/b6f8b1b69aa631b5716ef3f985c3b56de0e46c2499cc00d30c402b41f714/ty-0.0.55-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:32cbeba543e46de2a983ec6d525d8b56514f7422bd1e1b57c44ccf7bfa72c38a", size = 12128755, upload-time = "2026-06-27T00:27:20.55Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/a912531e51ee7e076b42972479290fa687c0f5e747b7e773f3033164acaa/ty-0.0.55-py3-none-win32.whl", hash = "sha256:52b968e24eb4f7a5c3bd251db1f99f60dd385890356d38fc619d84f1b423446a", size = 11117501, upload-time = "2026-06-27T00:27:22.714Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/99d59843bf8908a7f9f4d13fda107dbad07b7faa28ecd7860eacf363fb1c/ty-0.0.55-py3-none-win_amd64.whl", hash = "sha256:bf39cbfdc0add44d94bd3fff1f53c351418d134b6a66b87efdb7876d7b7a2224", size = 12150106, upload-time = "2026-06-27T00:27:24.881Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/44/20987505cedf2a865b08482f0eabc181fd9599b062964057ec8a128a4296/ty-0.0.55-py3-none-win_arm64.whl", hash = "sha256:f7f3700a9a060e8f1af11e4fb63fafcaf272b041781f4ccdfda2b3b5c6c1e439", size = 11560157, upload-time = "2026-06-27T00:27:27.332Z" },
 ]
 
 [[package]]
@@ -1404,15 +1407,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.48.0"
+version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds first-class **category** and **tag** support to LamPyrid, plus a small client cleanup.
Resolves #85 

Firefly III treats budget / category / tag as three complementary "extra info" fields on every transaction (validated against a live instance: unknown categories **and** tags are auto-created on use, same as expense/revenue accounts).

### Transactions (Tier 1)
- Output `Transaction` model now carries `category_id`, `category_name`, and `tags` (populated on read, emitted on create/bulk).
- `create_withdrawal` / `create_deposit` / `create_transfer` accept `category_name` / `category_id` + `tags`.
- `update_transaction` gains `category_id` and `tags` with **replace semantics**: an empty list clears all tags; omitting the field leaves them unchanged.
- `search_transactions` gains a `tags` filter (emits `tag_is:`, AND logic).

### Category & Tag domains (Tier 2)
- New read-only tools mounted via `compose_all_servers`:
  - `list_categories`, `get_category` (with period spend/earn totals)
  - `list_tags`, `get_tag` (by name or id)
- No create/delete tools — both auto-create when first used on a transaction.

### Client cleanup
- Moved the `/api/v1` prefix into the httpx `base_url`; the 39 client methods now use relative paths.

## Testing
- New integration tests for category/tag round-trips, auto-creation, tag replace/clear, search-by-tag, and the category/tag management tools.
- Updated existing transaction snapshots for the 3 new fields (regenerated on a fresh DB so account IDs are unchanged).
- Full suite: **240 passed**, ruff clean — run against a real Firefly III v6.6.3 instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)